### PR TITLE
use @none to ignore pwd when downloading drupal

### DIFF
--- a/files/d7_init.sh
+++ b/files/d7_init.sh
@@ -38,7 +38,7 @@ sudo chown apache:apache $SITEPATH
 SITE=`basename $SITEPATH`
 
 ## Build from drush make
-sudo -u apache drush -y dl drupal --drupal-project-rename=drupal --destination=$SITEPATH || exit 1;
+sudo -u apache drush @none -y dl drupal --drupal-project-rename=drupal --destination=$SITEPATH || exit 1;
 
 ## Set perms
 echo "Setting permissions."


### PR DESCRIPTION
I saw this in the instructions for installing the drupal vim module and it occured to me that it might get rid of the chdir() error/warning that we've been seeing. According to the drush aliases examples, "The built-in alias `@none` represents the state of no Drupal site."
