### PR TITLE
 Replace scripts tag with assets tag

### DIFF
--- a/files/d7_clean.sh
+++ b/files/d7_clean.sh
@@ -34,8 +34,10 @@ then
   sudo chmod 644 "$SITEPATH/default/files/.htaccess"
 
   ## Remove the content
+  ## /srv/libraries1/default isn't supposed to be writeable, so we need
+  ## to do some things as root
   echo "Deleting site files."
-  sudo -u apache rm -rf "$SITEPATH"
+  sudo  rm -rf "$SITEPATH"
 
   sudo systemctl restart httpd
 fi

--- a/files/d7_dump.sh
+++ b/files/d7_dump.sh
@@ -16,7 +16,7 @@ fi
 
 ## Init site if it doesn't exist
 if [[ ! -e $SITEPATH ]]; then
-    sudo d7_init.sh "$SITEPATH" || exit 1;
+    d7_init.sh "$SITEPATH" || exit 1;
 fi
 
 ## Grab the basename of the site to use in a few places.

--- a/files/d7_httpd_conf.sh
+++ b/files/d7_httpd_conf.sh
@@ -23,7 +23,12 @@ SITE=$(basename "$SITEPATH")
 
 ## Make the apache config
 echo "Generating Apache Config."
-sudo -u apache mkdir "/srv/$SITE/etc"
-sudo -u apache sh -c "sed "s/__SITE_DIR__/$SITE/g" /opt/d7/etc/d7_init_httpd_template > /srv/$SITE/etc/srv_$SITE.conf" || exit 1;
-sudo -u apache sh -c "sed -i "s/__SITE_NAME__/$SITE/g" /srv/$SITE/etc/srv_$SITE.conf" || exit 1;
+
+sudo -u apache mkdir "$SITEPATH/etc"
+sudo -u apache sh -c "sed "s/__SITE_DIR__/$SITE/g" /opt/d7/etc/d7_init_httpd_template > $SITEPATH/etc/srv_$SITE.conf" || exit 1;
+sudo -u apache sh -c "sed -i "s/__SITE_NAME__/$SITE/g" $SITEPATH/etc/srv_$SITE.conf" || exit 1;
+
+sudo semanage fcontext -a -t httpd_sys_content_t  "$SITEPATH/etc(/.*)?" || exit 1;
+sudo restorecon -R "$SITEPATH/etc" || exit 1;
+
 sudo systemctl restart httpd || exit 1;

--- a/files/d7_httpd_conf.sh
+++ b/files/d7_httpd_conf.sh
@@ -24,6 +24,6 @@ SITE=$(basename "$SITEPATH")
 ## Make the apache config
 echo "Generating Apache Config."
 sudo -u apache mkdir "/srv/$SITE/etc"
-sudo sh -c "sed "s/__SITE_DIR__/$SITE/g" /opt/d7/etc/d7_init_httpd_template > /srv/$SITE/etc/srv_$SITE.conf" || exit 1;
-sudo sh -c "sed -i "s/__SITE_NAME__/$SITE/g" /srv/$SITE/etc/srv_$SITE.conf" || exit 1;
+sudo -u apache sh -c "sed "s/__SITE_DIR__/$SITE/g" /opt/d7/etc/d7_init_httpd_template > /srv/$SITE/etc/srv_$SITE.conf" || exit 1;
+sudo -u apache sh -c "sed -i "s/__SITE_NAME__/$SITE/g" /srv/$SITE/etc/srv_$SITE.conf" || exit 1;
 sudo systemctl restart httpd || exit 1;

--- a/files/d7_init.sh
+++ b/files/d7_init.sh
@@ -102,4 +102,4 @@ sudo -u apache drush -y -r "$SITEPATH/drupal" site-install --site-name="$SITE" |
 d7_httpd_conf.sh "$SITEPATH" || exit 1;
 
 ## Apply security updates and clear caches.
-sudo d7_update.sh "$SITEPATH" || exit 1;
+d7_update.sh "$SITEPATH" || exit 1;

--- a/files/d7_init.sh
+++ b/files/d7_init.sh
@@ -99,7 +99,7 @@ sudo -u apache drush -y sql-create --db-su=root --db-su-pw="$ROOTDBPSSWD" -r "$S
 sudo -u apache drush -y -r "$SITEPATH/drupal" site-install --site-name="$SITE" || exit 1;
 
 ## Apply the apache config
-sudo d7_httpd_conf.sh "$SITEPATH" || exit 1;
+d7_httpd_conf.sh "$SITEPATH" || exit 1;
 
 ## Apply security updates and clear caches.
 sudo d7_update.sh "$SITEPATH" || exit 1;

--- a/files/d7_make.sh
+++ b/files/d7_make.sh
@@ -22,7 +22,7 @@ if [[ ! -e $SITEPATH ]]; then
 fi
 
 ## Dump DB before touching anything
-sudo d7_dump.sh "$SITEPATH" || exit 1;
+d7_dump.sh "$SITEPATH" || exit 1;
 
 ## Delete build dir if it's there
 sudo -u apache rm -rf "$SITEPATH/drupal_build"
@@ -66,4 +66,4 @@ sudo -u apache mv "$SITEPATH/drupal" "$SITEPATH/drupal_bak"
 sudo -u apache mv "$SITEPATH/drupal_build" "$SITEPATH/drupal"
 
 ## Apply security updates and clear caches.
-sudo d7_update.sh "$SITEPATH" || exit 1;
+d7_update.sh "$SITEPATH" || exit 1;

--- a/files/d7_make.sh
+++ b/files/d7_make.sh
@@ -18,7 +18,7 @@ fi
 
 ## Init site if it doesn't exist
 if [[ ! -e $SITEPATH ]]; then
-    sudo d7_init.sh "$SITEPATH" || exit 1;
+    d7_init.sh "$SITEPATH" || exit 1;
 fi
 
 ## Dump DB before touching anything

--- a/files/d7_sync.sh
+++ b/files/d7_sync.sh
@@ -22,7 +22,7 @@ SITE=$(basename "$SITEPATH")
 
 ## Init site if it doesn't exist
 if [[ ! -e $SITEPATH ]]; then
-    sudo d7_init.sh "$SITEPATH" || exit 1;
+    d7_init.sh "$SITEPATH" || exit 1;
 fi
 
 ## Make the sync directory

--- a/files/d7_sync.sh
+++ b/files/d7_sync.sh
@@ -44,10 +44,12 @@ sudo semanage fcontext -a -t httpd_sys_rw_content_t  "$SITEPATH/default/files_sy
 sudo restorecon -R "$SITEPATH/default" || exit 1;
 
 ## Now that everything is ready, swap in the synced files
+## /srv/libraries1/default isn't supposed to be writeable, so we need
+## to do some things as root.
 echo "Placing synced files."
-sudo -u apache rm -rf "$SITEPATH/default/files_bak"
-sudo -u apache mv "$SITEPATH/default/files" "$SITEPATH/default/files_bak"
-sudo -u apache mv "$SITEPATH/default/files_sync" "$SITEPATH/default/files"
+sudo rm -rf "$SITEPATH/default/files_bak"
+sudo mv "$SITEPATH/default/files" "$SITEPATH/default/files_bak"
+sudo mv "$SITEPATH/default/files_sync" "$SITEPATH/default/files"
 
 ## Perform sql-dump on source host
 ssh -A "$SRCHOST" drush -r "$ORIGIN_SITEPATH/drupal" sql-dump --result-file="$TEMPDIR/drupal_$SITE.sql"

--- a/files/d7_sync.sh
+++ b/files/d7_sync.sh
@@ -69,4 +69,4 @@ rm "$TEMPDIR/drupal_$SITE.sql"
 echo "Database synced."
 
 ## Apply security updates and clear caches.
-sudo d7_update.sh "$SITEPATH" || exit 1;
+d7_update.sh "$SITEPATH" || exit 1;

--- a/files/d7_update.sh
+++ b/files/d7_update.sh
@@ -13,7 +13,7 @@ else
 fi
 
 ## Dump DB before touching anything
-sudo d7_dump.sh "$SITEPATH" || exit 1;
+d7_dump.sh "$SITEPATH" || exit 1;
 
 ## Enable update manager.
 sudo -u apache drush -y en update -r "$SITEPATH/drupal" || exit 1;

--- a/tasks/assets.yml
+++ b/tasks/assets.yml
@@ -1,0 +1,52 @@
+---
+- name: Ensure /opt/d7/bin exists
+  file:
+    path: /opt/d7/bin
+    state: directory
+    mode: 0655
+    owner: root
+    group: wheel
+    recurse: yes
+
+- name: scripts to /opt/d7/bin
+  copy:
+    src: "{{ item }}"
+    dest: /opt/d7/bin/
+    mode: 0754
+    owner: root
+    group: wheel
+  with_items:
+      - d7_init.sh
+      - d7_make.sh
+      - d7_sync.sh
+      - d7_clean.sh
+      - d7_httpd_conf.sh
+      - d7_update.sh
+      - d7_dump.sh
+  tags:
+    scripts
+
+- name: Ensure /opt/d7/etc exists
+  file:
+    path: /opt/d7/etc
+    state: directory
+    mode: 0655
+    owner: root
+    group: wheel
+    recurse: yes
+
+
+- name: Install httpd template file
+  copy:
+    mode: 0444
+    src: d7_init_httpd_template
+    dest: /opt/d7/etc
+
+
+- name: Install d7  config
+  template:
+    src: d7_conf.sh.j2
+    dest: /opt/d7/etc/d7_conf.sh
+    owner: root
+    group: wheel
+    mode: 0444

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -15,6 +15,7 @@
 
 - name: Add httpd template file
   copy:
+    mode: 0444
     src: d7_init_httpd_template
     dest: /opt/d7/etc
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -13,61 +13,11 @@
   - php-drush-drush
   - mariadb
 
-- name: Add httpd template file
-  copy:
-    mode: 0444
-    src: d7_init_httpd_template
-    dest: /opt/d7/etc
-
-- name: Ensure /opt/d7/bin exists
-  file:
-    path: /opt/d7/bin
-    state: directory
-    mode: 0655
-    owner: root
-    group: wheel
-    recurse: yes
-
-- name: scripts to /opt/d7/bin
-  copy:
-    src: "{{ item }}"
-    dest: /opt/d7/bin/
-    mode: 0754
-    owner: root
-    group: wheel
-  with_items:
-      - d7_init.sh
-      - d7_make.sh
-      - d7_sync.sh
-      - d7_clean.sh
-      - d7_httpd_conf.sh
-      - d7_update.sh
-      - d7_dump.sh
-  tags:
-    scripts
-
-- name: Ensure /opt/d7/etc exists
-  file:
-    path: /opt/d7/etc
-    state: directory
-    mode: 0655
-    owner: root
-    group: wheel
-    recurse: yes
-
-- name: Add ops config
-  template:
-    src: d7_conf.sh.j2
-    dest: /opt/d7/etc/d7_conf.sh
-    owner: root
-    group: wheel
-    mode: 0444
 
 - name: Add config include to http.conf
   lineinfile:
     dest: /etc/httpd/conf/httpd.conf
     line: "IncludeOptional \"/srv/*/etc/*.conf\""
-    
     
 - name: Ensure /etc/profile.d/d7-ops.sh exists
   file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,3 +1,7 @@
 ---
 - include: install.yml
   sudo: yes
+
+- include: assets.yml
+  sudo: yes
+  tags: assets


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
- Moves all file and template installation to asset.yml and tags that include in main.yml as `assets`.
- Fixes order of asset creation so /opt/d7/etc exists before we put stuff there. 
## Motivation and Context

Allows for update of role assets in more generalized format than "scripts" tag did, as requested in comments on #14. Based on #19. 
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->
- vagrant up and init/make/sync/clean of libraries site 
