### PR TITLE
Adding assets tag

### DIFF
--- a/tasks/assets.yml
+++ b/tasks/assets.yml
@@ -1,0 +1,52 @@
+---
+- name: Ensure /opt/d7/bin exists
+  file:
+    path: /opt/d7/bin
+    state: directory
+    mode: 0655
+    owner: root
+    group: wheel
+    recurse: yes
+
+- name: scripts to /opt/d7/bin
+  copy:
+    src: "{{ item }}"
+    dest: /opt/d7/bin/
+    mode: 0754
+    owner: root
+    group: wheel
+  with_items:
+      - d7_init.sh
+      - d7_make.sh
+      - d7_sync.sh
+      - d7_clean.sh
+      - d7_httpd_conf.sh
+      - d7_update.sh
+      - d7_dump.sh
+  tags:
+    scripts
+
+- name: Ensure /opt/d7/etc exists
+  file:
+    path: /opt/d7/etc
+    state: directory
+    mode: 0655
+    owner: root
+    group: wheel
+    recurse: yes
+
+
+- name: Install httpd template file
+  copy:
+    mode: 0444
+    src: d7_init_httpd_template
+    dest: /opt/d7/etc
+
+
+- name: Install d7  config
+  template:
+    src: d7_conf.sh.j2
+    dest: /opt/d7/etc/d7_conf.sh
+    owner: root
+    group: wheel
+    mode: 0444

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -13,61 +13,11 @@
   - php-drush-drush
   - mariadb
 
-- name: Add httpd template file
-  copy:
-    mode: 0444
-    src: d7_init_httpd_template
-    dest: /opt/d7/etc
-
-- name: Ensure /opt/d7/bin exists
-  file:
-    path: /opt/d7/bin
-    state: directory
-    mode: 0655
-    owner: root
-    group: wheel
-    recurse: yes
-
-- name: scripts to /opt/d7/bin
-  copy:
-    src: "{{ item }}"
-    dest: /opt/d7/bin/
-    mode: 0754
-    owner: root
-    group: wheel
-  with_items:
-      - d7_init.sh
-      - d7_make.sh
-      - d7_sync.sh
-      - d7_clean.sh
-      - d7_httpd_conf.sh
-      - d7_update.sh
-      - d7_dump.sh
-  tags:
-    scripts
-
-- name: Ensure /opt/d7/etc exists
-  file:
-    path: /opt/d7/etc
-    state: directory
-    mode: 0655
-    owner: root
-    group: wheel
-    recurse: yes
-
-- name: Add ops config
-  template:
-    src: d7_conf.sh.j2
-    dest: /opt/d7/etc/d7_conf.sh
-    owner: root
-    group: wheel
-    mode: 0444
 
 - name: Add config include to http.conf
   lineinfile:
     dest: /etc/httpd/conf/httpd.conf
     line: "IncludeOptional \"/srv/*/etc/*.conf\""
-    
     
 - name: Ensure /etc/profile.d/d7-ops.sh exists
   file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,3 +1,7 @@
 ---
 - include: install.yml
   sudo: yes
+
+- include: assets.yml
+  sudo: yes
+  tags: assets


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
- Moves all file and template installation to asset.yml and tags that include in main.yml as `assets`.
- Fixes order of asset creation so /opt/d7/etc exists before we put stuff there. 
## Motivation and Context

Allows for update of role assets in more generalized format than "scripts" tag did, as requested in comments on #14. Based on #19. 
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->
- vagrant up and init/make/sync/clean of libraries site 
