### PR TITLE
Add d7_importdb.sh with optional path argument 

### DIFF
--- a/files/d7_dump.sh
+++ b/files/d7_dump.sh
@@ -26,4 +26,4 @@ SITE=$(basename "$SITEPATH")
 sudo -u apache mkdir -p "$SITEPATH/db"
 
 ## Perform sql-dump
-sudo -u apache drush -r "$SITEPATH/drupal" sql-dump --result-file="$SITEPATH/db/drupal_$SITE.sql"
+sudo -u apache drush -r "$SITEPATH/drupal" sql-dump --result-file="$SITEPATH/db/drupal_${SITE}_dump.sql"

--- a/files/d7_importdb.sh
+++ b/files/d7_importdb.sh
@@ -5,28 +5,35 @@ PATH=/opt/d7/bin:/usr/local/bin:/usr/bin:/bin:/sbin:$PATH
 source /opt/d7/etc/d7_conf.sh
 
 ## Require arguments
-if [ ! -z "$1" ] 
+if [  -z "$1" ]
 then
-    SITEPATH=$1
-    echo "Importing SITEPATH content from $DUMP"
-else
-  echo "Requires site path (eg. /srv/sample)."
-  exit 1;
+   echo "Requires site path (eg. /srv/sample)."
+   exit 1;
+fi
+SITEPATH=$1
+
+if [[ ! -e $SITEPATH ]]; then
+    echo "No site exists at ${SITEPATH}."
+    exit 1;
 fi
 
 ## Grab the basename of the NEW site to use in a few places.
 SITE=$(basename "$SITEPATH")
 
-## Init site if it doesn't exist
-if [[ ! -e $SITEPATH ]]; then
-    echo "No site exists at ${SITEPATH}."
-    exit
-fi
+if [[ ! -z "$2" ]]
+then
+    DBFILE=$2
+else
+    DBFILE="${SITEPATH}/db/drupal_${SITE}_dump.sql"
+fi       
 
 
 ## Load sql-dump to local DB
-sudo -u apache drush sql-cli -r "$SITEPATH/drupal" < "$SITEPATH/db/drupal_${SITE}_dump.sql" || exit 1;
+
+echo "Synching database for $SITE from file at $DBFILE."
+sudo -u apache drush sql-cli -r "$SITEPATH/drupal" < "${DBFILE}" || exit 1;
 echo "Database synced."
+echo
 
 ## Apply security updates and clear caches.
 d7_update.sh "$SITEPATH" || exit 1;

--- a/files/d7_importdb.sh
+++ b/files/d7_importdb.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+## Sync Drupal files & DB from source host
+PATH=/opt/d7/bin:/usr/local/bin:/usr/bin:/bin:/sbin:$PATH
+
+source /opt/d7/etc/d7_conf.sh
+
+## Require arguments
+if [ ! -z "$1" ] 
+then
+    SITEPATH=$1
+    echo "Importing SITEPATH content from $DUMP"
+else
+  echo "Requires site path (eg. /srv/sample)."
+  exit 1;
+fi
+
+## Grab the basename of the NEW site to use in a few places.
+SITE=$(basename "$SITEPATH")
+
+## Init site if it doesn't exist
+if [[ ! -e $SITEPATH ]]; then
+    echo "No site exists at ${SITEPATH}."
+    exit
+fi
+
+
+## Load sql-dump to local DB
+sudo -u apache drush sql-cli -r "$SITEPATH/drupal" < "$SITEPATH/db/drupal_${SITE}_dump.sql" || exit 1;
+echo "Database synced."
+
+## Apply security updates and clear caches.
+d7_update.sh "$SITEPATH" || exit 1;

--- a/files/d7_sync.sh
+++ b/files/d7_sync.sh
@@ -59,13 +59,6 @@ rsync --omit-dir-times "$SRCHOST:$TEMPDIR/drupal_$SITE.sql" "$TEMPDIR/"
 
 ## Load sql-dump to local DB
 sudo -u apache drush sql-cli -r "$SITEPATH/drupal" < "$TEMPDIR/drupal_$SITE.sql" || exit 1;
-
-## Cleanup sql-dumps
-if [ "localhost" != "$SRCHOST" ]; then 
-    ssh -A "$SRCHOST" rm "$TEMPDIR/drupal_$SITE.sql"
-fi
-
-rm "$TEMPDIR/drupal_$SITE.sql"
 echo "Database synced."
 
 ## Apply security updates and clear caches.

--- a/files/d7_sync.sh
+++ b/files/d7_sync.sh
@@ -18,7 +18,7 @@ fi
 
 ## Grab the basename of the NEW site to use in a few places.
 SITE=$(basename "$SITEPATH")
-
+ORIGIN_SITE=$(basename "$ORIGIN_SITEPATH")
 
 ## Init site if it doesn't exist
 if [[ ! -e $SITEPATH ]]; then
@@ -52,13 +52,13 @@ sudo mv "$SITEPATH/default/files" "$SITEPATH/default/files_bak"
 sudo mv "$SITEPATH/default/files_sync" "$SITEPATH/default/files"
 
 ## Perform sql-dump on source host
-ssh -A "$SRCHOST" drush -r "$ORIGIN_SITEPATH/drupal" sql-dump --result-file="$ORIGIN_SITEPATH/db/drupal_${SITE}_sync.sql"
+ssh -A "$SRCHOST" drush -r "$ORIGIN_SITEPATH/drupal" sql-dump --result-file="$ORIGIN_SITEPATH/db/drupal_${ORIGIN_SITE}_sync.sql"
 
 ## Sync sql-dump
-rsync --omit-dir-times "$SRCHOST:$SITEPATH/db/drupal_${SITE}_sync.sql" "$SITEPATH/db/"
+rsync --omit-dir-times "$SRCHOST:$ORIGIN_SITEPATH/db/drupal_${ORIGIN_SITE}_sync.sql" "$SITEPATH/db/"
 
 ## Load sql-dump to local DB
-sudo -u apache drush sql-cli -r "$SITEPATH/drupal" < "$SITEPATH/db/drupal_${SITE}_sync.sql" || exit 1;
+sudo -u apache drush sql-cli -r "$SITEPATH/drupal" < "$SITEPATH/db/drupal_${ORIGIN_SITE}_sync.sql" || exit 1;
 echo "Database synced."
 
 ## Apply security updates and clear caches.

--- a/files/d7_sync.sh
+++ b/files/d7_sync.sh
@@ -52,13 +52,13 @@ sudo mv "$SITEPATH/default/files" "$SITEPATH/default/files_bak"
 sudo mv "$SITEPATH/default/files_sync" "$SITEPATH/default/files"
 
 ## Perform sql-dump on source host
-ssh -A "$SRCHOST" drush -r "$ORIGIN_SITEPATH/drupal" sql-dump --result-file="$TEMPDIR/drupal_$SITE.sql"
+ssh -A "$SRCHOST" drush -r "$ORIGIN_SITEPATH/drupal" sql-dump --result-file="$ORIGIN_SITEPATH/db/drupal_${SITE}_sync.sql"
 
 ## Sync sql-dump
-rsync --omit-dir-times "$SRCHOST:$TEMPDIR/drupal_$SITE.sql" "$TEMPDIR/"
+rsync --omit-dir-times "$SRCHOST:$SITEPATH/db/drupal_${SITE}_sync.sql" "$SITEPATH/db/"
 
 ## Load sql-dump to local DB
-sudo -u apache drush sql-cli -r "$SITEPATH/drupal" < "$TEMPDIR/drupal_$SITE.sql" || exit 1;
+sudo -u apache drush sql-cli -r "$SITEPATH/drupal" < "$SITEPATH/db/drupal_${SITE}_sync.sql" || exit 1;
 echo "Database synced."
 
 ## Apply security updates and clear caches.

--- a/tasks/assets.yml
+++ b/tasks/assets.yml
@@ -16,13 +16,14 @@
     owner: root
     group: wheel
   with_items:
+      - d7_clean.sh
+      - d7_dump.sh
+      - d7_httpd_conf.sh
       - d7_init.sh
+      - d7_importdb.sh
       - d7_make.sh
       - d7_sync.sh
-      - d7_clean.sh
-      - d7_httpd_conf.sh
       - d7_update.sh
-      - d7_dump.sh
   tags:
     scripts
 


### PR DESCRIPTION
- adds new import script.
- Moves sync db dump from $TEMPDIR to sync-specific file in $SITEPATH/db.
## Motivation and Context

Adds database import script so that we can re-import a site after vagrant destroy. 
Addresses parts of #12, depends on #20.
## How Has This Been Tested?
- db import of standard and sync db
