### PR TITLE
Use d7_importdb.sh in d7_sync.sh

### DIFF
--- a/files/d7_sync.sh
+++ b/files/d7_sync.sh
@@ -1,4 +1,4 @@
->#!/usr/bin/env bash
+#!/usr/bin/env bash
 ## Sync Drupal files & DB from source host
 PATH=/opt/d7/bin:/usr/local/bin:/usr/bin:/bin:/sbin:$PATH
 

--- a/files/d7_sync.sh
+++ b/files/d7_sync.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+>#!/usr/bin/env bash
 ## Sync Drupal files & DB from source host
 PATH=/opt/d7/bin:/usr/local/bin:/usr/bin:/bin:/sbin:$PATH
 
@@ -57,9 +57,6 @@ ssh -A "$SRCHOST" drush -r "$ORIGIN_SITEPATH/drupal" sql-dump --result-file="$OR
 ## Sync sql-dump
 rsync --omit-dir-times "$SRCHOST:$ORIGIN_SITEPATH/db/drupal_${ORIGIN_SITE}_sync.sql" "$SITEPATH/db/"
 
-## Load sql-dump to local DB
-sudo -u apache drush sql-cli -r "$SITEPATH/drupal" < "$SITEPATH/db/drupal_${ORIGIN_SITE}_sync.sql" || exit 1;
-echo "Database synced."
 
-## Apply security updates and clear caches.
-d7_update.sh "$SITEPATH" || exit 1;
+## Import sql dump
+d7_importdb.sh "$SITEPATH" "$SITEPATH/db/drupal_${ORIGIN_SITE}_sync.sql" || exit 1;


### PR DESCRIPTION
This PR replaces the db import code in the d7_sync.sh with the d7_importdb script.
## Motivation and Context

Refactor motivated by work on  #12
## How Has This Been Tested?
- Import and sync of sites
