### PR TITLE
Parameterize the database admin user

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,6 +20,11 @@ httpd_cert_path: '/etc/pki/tls/certs/'
 httpd_key_path: '/etc/pki/tls/private/'
 
 environment_name: "vagrant"
-db_host: "localhost"
-db_port: "3306"
+
+mariadb_host: "localhost"
+mariadb_port: "3306"
+mariadb_root_user: 'root'
+mariadb_root_pass: 'root'
+
+
 temp_dir: "/var/local/backups/drupal/temp"

--- a/files/d7_importdb.sh
+++ b/files/d7_importdb.sh
@@ -27,7 +27,7 @@ else
     DBFILE="${SITEPATH}/db/drupal_${SITE}_dump.sql"
 fi       
 
-if drush sqlq -r $SITEPATH
+if drush sqlq -r $SITEPATH/drupal
 then
     echo "Target DB exists. "
 else

--- a/files/d7_importdb.sh
+++ b/files/d7_importdb.sh
@@ -28,6 +28,20 @@ else
 fi       
 
 
+
+ROOTDBPSSWD="root"
+
+
+if drush sqlq -r $SITEPATH
+then
+    echo "Require database exists"
+else
+    ## Create the Drupal database
+    sudo -u apache drush -y sql-create --db-su=root --db-su-pw="$ROOTDBPSSWD" -r "$SITEPATH/drupal" || exit 1;
+fi
+
+
+
 ## Load sql-dump to local DB
 
 echo "Synching database for $SITE from file at $DBFILE."

--- a/files/d7_importdb.sh
+++ b/files/d7_importdb.sh
@@ -35,7 +35,7 @@ else
 
 
     # Get DB admin user
-    read -r -e -p "Enter MYSQL admin user: " -i "$D7_DBSU" DBSU
+    read -r -e -p "Enter MYSQL admin user: " -i "$D7_DBSU" D7_DBSU
     # Get DB admin password
     read -r -s -p "Enter MYSQL root password: " D7_DBSU_PASS
     while ! mysql -u  "$D7_DBSU" -p"$D7_DBSU_PASS"  -e ";" ; do

--- a/files/d7_importdb.sh
+++ b/files/d7_importdb.sh
@@ -43,7 +43,7 @@ else
     done
     
     ## Create the Drupal database
-    sudo -u apache drush -y sql-create --db-su="D7_DBSU" --db-su-pw="$D7_DBSU_PASS" -r "$SITEPATH/drupal" || exit 1;
+    sudo -u apache drush -y sql-create --db-su="$D7_DBSU" --db-su-pw="$D7_DBSU_PASS" -r "$SITEPATH/drupal" || exit 1;
 fi
 
 ## Load sql-dump to local DB

--- a/files/d7_importdb.sh
+++ b/files/d7_importdb.sh
@@ -34,7 +34,7 @@ else
     echo "Target DB doesn't exist, we need to create it. "
 
     # Get root DB password
-    read -r -s -p "Enter MYSQL root password: " ROOTDBPSSWD
+    read -r -s -p "Enter MYSQL admin password: " ROOTDBPSSWD
     while ! mysql -u root -p"$ROOTDBPSSWD"  -e ";" ; do
 	read -r -s -p "Can't connect. Re-enter password to try again: " ROOTDBPSSWD
     done

--- a/files/d7_importdb.sh
+++ b/files/d7_importdb.sh
@@ -32,8 +32,13 @@ then
     echo "Target DB exists. "
 else
     echo "Target DB doesn't exist, we need to create it. "
+
     # Get root DB password
     read -r -s -p "Enter MYSQL root password: " ROOTDBPSSWD
+    while ! mysql -u root -p"$ROOTDBPSSWD"  -e ";" ; do
+	read -r -s -p "Can't connect. Re-enter password to try again: " ROOTDBPSSWD
+    done
+    
     ## Create the Drupal database
     sudo -u apache drush -y sql-create --db-su=root --db-su-pw="$ROOTDBPSSWD" -r "$SITEPATH/drupal" || exit 1;
 fi

--- a/files/d7_importdb.sh
+++ b/files/d7_importdb.sh
@@ -27,26 +27,21 @@ else
     DBFILE="${SITEPATH}/db/drupal_${SITE}_dump.sql"
 fi       
 
-
-
-ROOTDBPSSWD="root"
-
-
 if drush sqlq -r $SITEPATH
 then
-    echo "Require database exists"
+    echo "Target DB exists. "
 else
+    echo "Target DB doesn't exist, we need to create it. "
+    # Get root DB password
+    read -r -s -p "Enter MYSQL root password: " ROOTDBPSSWD
     ## Create the Drupal database
     sudo -u apache drush -y sql-create --db-su=root --db-su-pw="$ROOTDBPSSWD" -r "$SITEPATH/drupal" || exit 1;
 fi
 
-
-
 ## Load sql-dump to local DB
-
-echo "Synching database for $SITE from file at $DBFILE."
+echo "Importing database for $SITE from file at $DBFILE."
 sudo -u apache drush sql-cli -r "$SITEPATH/drupal" < "${DBFILE}" || exit 1;
-echo "Database synced."
+echo "Database imported."
 echo
 
 ## Apply security updates and clear caches.

--- a/files/d7_importdb.sh
+++ b/files/d7_importdb.sh
@@ -33,14 +33,17 @@ then
 else
     echo "Target DB doesn't exist, we need to create it. "
 
-    # Get root DB password
-    read -r -s -p "Enter MYSQL admin password: " ROOTDBPSSWD
-    while ! mysql -u root -p"$ROOTDBPSSWD"  -e ";" ; do
-	read -r -s -p "Can't connect. Re-enter password to try again: " ROOTDBPSSWD
+
+    # Get DB admin user
+    read -r -e -p "Enter MYSQL admin user: " -i "$D7_DBSU" DBSU
+    # Get DB admin password
+    read -r -s -p "Enter MYSQL root password: " ROOTDBPSSWD
+    while ! mysql -u  "$D7_DBSU" -p"$ROOTDBPSSWD"  -e ";" ; do
+	read -r -s -p "Can't connect, please retry: " ROOTDBPSSWD
     done
     
     ## Create the Drupal database
-    sudo -u apache drush -y sql-create --db-su=root --db-su-pw="$ROOTDBPSSWD" -r "$SITEPATH/drupal" || exit 1;
+    sudo -u apache drush -y sql-create --db-su="D7_DBSU" --db-su-pw="$ROOTDBPSSWD" -r "$SITEPATH/drupal" || exit 1;
 fi
 
 ## Load sql-dump to local DB

--- a/files/d7_importdb.sh
+++ b/files/d7_importdb.sh
@@ -27,7 +27,7 @@ else
     DBFILE="${SITEPATH}/db/drupal_${SITE}_dump.sql"
 fi       
 
-if drush sqlq -r $SITEPATH/drupal
+if drush sqlq -r "$SITEPATH/drupal"
 then
     echo "Target DB exists. "
 else

--- a/files/d7_importdb.sh
+++ b/files/d7_importdb.sh
@@ -37,13 +37,13 @@ else
     # Get DB admin user
     read -r -e -p "Enter MYSQL admin user: " -i "$D7_DBSU" DBSU
     # Get DB admin password
-    read -r -s -p "Enter MYSQL root password: " ROOTDBPSSWD
-    while ! mysql -u  "$D7_DBSU" -p"$ROOTDBPSSWD"  -e ";" ; do
-	read -r -s -p "Can't connect, please retry: " ROOTDBPSSWD
+    read -r -s -p "Enter MYSQL root password: " D7_DBSU_PASS
+    while ! mysql -u  "$D7_DBSU" -p"$D7_DBSU_PASS"  -e ";" ; do
+	read -r -s -p "Can't connect, please retry: " D7_DBSU_PASS
     done
     
     ## Create the Drupal database
-    sudo -u apache drush -y sql-create --db-su="D7_DBSU" --db-su-pw="$ROOTDBPSSWD" -r "$SITEPATH/drupal" || exit 1;
+    sudo -u apache drush -y sql-create --db-su="D7_DBSU" --db-su-pw="$D7_DBSU_PASS" -r "$SITEPATH/drupal" || exit 1;
 fi
 
 ## Load sql-dump to local DB

--- a/files/d7_init.sh
+++ b/files/d7_init.sh
@@ -29,9 +29,9 @@ echo
 # Get DB admin user
 read -r -e -p "Enter MYSQL admin user: " -i "$D7_DBSU" DBSU
 # Get DB admin password
-read -r -s -p "Enter MYSQL root password: " ROOTDBPSSWD
-while ! mysql -u "$D7_DBSU: -p"$ROOTDBPSSWD"  -e ";" ; do
-    read -r -s -p "Can't connect, please retry: " ROOTDBPSSWD
+read -r -s -p "Enter MYSQL root password: " D7_DBSU_PASS
+while ! mysql -u "$D7_DBSU: -p"$D7_DBSU_PASS"  -e ";" ; do
+    read -r -s -p "Can't connect, please retry: " D7_DBSU_PASS
 done
 
 # Generate Drupal DB password
@@ -95,7 +95,7 @@ sudo -u apache echo "$SETTINGSPHP"| sudo -u apache tee -a "$SITEPATH/default/set
 sudo -u apache chmod 444 "$SITEPATH/default/settings.php"
 
 ## Create the Drupal database
-sudo -u apache drush -y sql-create --db-su="${D7_DBSU}" --db-su-pw="$ROOTDBPSSWD" -r "$SITEPATH/drupal" || exit 1;
+sudo -u apache drush -y sql-create --db-su="${D7_DBSU}" --db-su-pw="$D7_DBSU_PASS" -r "$SITEPATH/drupal" || exit 1;
 
 ## Do the Drupal install
 sudo -u apache drush -y -r "$SITEPATH/drupal" site-install --site-name="$SITE" || exit 1;

--- a/files/d7_init.sh
+++ b/files/d7_init.sh
@@ -21,14 +21,16 @@ if [[ -e "$SITEPATH" ]]; then
 fi
 
 # Get mysql host
-read -r -e -p "Enter MYSQL host name: " -i "$DEFAULT_DBHOST" DBHOST
+read -r -e -p "Enter MYSQL host name: " -i "$D7_DBHOST" DBHOST
 # Get mysql host
-read -r -e -p "Enter MYSQL host port: " -i "$DEFAULT_DBPORT" DBPORT
-# Get root DB password
-read -r -s -p "Enter MYSQL root password: " ROOTDBPSSWD
+read -r -e -p "Enter MYSQL host port: " -i "$D7_DBPORT" DBPORT
 echo
 
-while ! mysql -u root -p"$ROOTDBPSSWD"  -e ";" ; do
+# Get DB admin user
+read -r -e -p "Enter MYSQL admin user: " -i "$D7_DBSU" DBSU
+# Get DB admin password
+read -r -s -p "Enter MYSQL root password: " ROOTDBPSSWD
+while ! mysql -u "$D7_DBSU: -p"$ROOTDBPSSWD"  -e ";" ; do
     read -r -s -p "Can't connect, please retry: " ROOTDBPSSWD
 done
 
@@ -93,7 +95,7 @@ sudo -u apache echo "$SETTINGSPHP"| sudo -u apache tee -a "$SITEPATH/default/set
 sudo -u apache chmod 444 "$SITEPATH/default/settings.php"
 
 ## Create the Drupal database
-sudo -u apache drush -y sql-create --db-su=root --db-su-pw="$ROOTDBPSSWD" -r "$SITEPATH/drupal" || exit 1;
+sudo -u apache drush -y sql-create --db-su="${D7_DBSU}" --db-su-pw="$ROOTDBPSSWD" -r "$SITEPATH/drupal" || exit 1;
 
 ## Do the Drupal install
 sudo -u apache drush -y -r "$SITEPATH/drupal" site-install --site-name="$SITE" || exit 1;

--- a/files/d7_init.sh
+++ b/files/d7_init.sh
@@ -88,6 +88,11 @@ read -r -d '' SETTINGSPHP <<- EOF
     ),
   ),
 );
+
+## Set public-facing hostname.
+\$base_url = 'https://${SITE}.${D7_HOST_SUFFIX}';
+\$cookie_domain = '${SITE}.${D7_HOST_SUFFIX}';
+
 EOF
 
 sudo -u apache cp "$SITEPATH/default/default.settings.php" "$SITEPATH/default/settings.php"

--- a/files/d7_init.sh
+++ b/files/d7_init.sh
@@ -30,7 +30,7 @@ echo
 read -r -e -p "Enter MYSQL admin user: " -i "$D7_DBSU" DBSU
 # Get DB admin password
 read -r -s -p "Enter MYSQL root password: " D7_DBSU_PASS
-while ! mysql -u "$D7_DBSU: -p"$D7_DBSU_PASS"  -e ";" ; do
+while ! mysql -u "$D7_DBSU" -p"$D7_DBSU_PASS"  -e ";" ; do
     read -r -s -p "Can't connect, please retry: " D7_DBSU_PASS
 done
 

--- a/files/d7_init.sh
+++ b/files/d7_init.sh
@@ -88,11 +88,6 @@ read -r -d '' SETTINGSPHP <<- EOF
     ),
   ),
 );
-
-## Set public-facing hostname.
-\$base_url = 'https://${SITE}.${D7_HOST_SUFFIX}';
-\$cookie_domain = '${SITE}.${D7_HOST_SUFFIX}';
-
 EOF
 
 sudo -u apache cp "$SITEPATH/default/default.settings.php" "$SITEPATH/default/settings.php"

--- a/templates/d7_conf.sh.j2
+++ b/templates/d7_conf.sh.j2
@@ -1,6 +1,10 @@
 # tag for drupal boxes
 ENV_NAME="{{ environment_name }}"
 
+# Public facing host name
+D7_HOST_SUFFIX="{{httpd_dn_suffix}}"
+
+
 # Default MySQL target
 D7_DBHOST="{{ mariadb_host }}"
 D7_DBPORT="{{ mariadb_port }}"

--- a/templates/d7_conf.sh.j2
+++ b/templates/d7_conf.sh.j2
@@ -1,10 +1,6 @@
 # tag for drupal boxes
 ENV_NAME="{{ environment_name }}"
 
-# Public facing host name
-D7_HOST_SUFFIX="{{httpd_dn_suffix}}"
-
-
 # Default MySQL target
 D7_DBHOST="{{ mariadb_host }}"
 D7_DBPORT="{{ mariadb_port }}"

--- a/templates/d7_conf.sh.j2
+++ b/templates/d7_conf.sh.j2
@@ -2,8 +2,9 @@
 ENV_NAME="{{ environment_name }}"
 
 # Default MySQL target
-DEFAULT_DBHOST="{{ db_host }}"
-DEFAULT_DBPORT="{{ db_port }}"
+D7_DBHOST="{{ mariadb_host }}"
+D7_DBPORT="{{ mariadb_port }}"
+D7_DBSU="{{ mariadb_root_user}}"
 
 # Writable dir on both local and source hosts
 TEMPDIR="{{ temp_dir }}"


### PR DESCRIPTION
This PR cleans up database-related variable names and let users set the db admin user name when they init a drupal site.
## Motivation and Context

Addresses issue #29, based on PR #28
## How Has This Been Tested?

Successful init of Drupal sits. 
