### PR TITLE
Remove unneccessary temp dir stuff.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,4 +27,3 @@ mariadb_root_user: 'root'
 mariadb_root_pass: 'root'
 
 
-temp_dir: "/var/local/backups/drupal/temp"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -30,12 +30,3 @@
   lineinfile: "dest=/etc/profile.d/d7-ops.sh line='export PATH=/opt/d7/bin:$PATH'"
 - name: Add ops scripts to sudo secure_path
   lineinfile: "dest=/etc/sudoers state=present regexp='^Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin$' line='Defaults    secure_path = /opt/d7/bin:/sbin:/bin:/usr/sbin:/usr/bin' validate='visudo -cf %s'"
-
-- name: Ensure temp dir exists
-  file:
-    path: "{{ temp_dir }}"
-    state: directory
-    mode: 0770
-    owner: root
-    group: wheel
-    recurse: yes

--- a/templates/d7_conf.sh.j2
+++ b/templates/d7_conf.sh.j2
@@ -10,5 +10,3 @@ D7_DBHOST="{{ mariadb_host }}"
 D7_DBPORT="{{ mariadb_port }}"
 D7_DBSU="{{ mariadb_root_user}}"
 
-# Writable dir on both local and source hosts
-TEMPDIR="{{ temp_dir }}"


### PR DESCRIPTION
SQL dumps now live inside the site folder, so there's no need for a temp dir. 
## Motivation and Context

General cleanup. 
## How Has This Been Tested?

Simple change, but still needs testing.
