### PR TITLE
Make DB variables consistent. 

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,7 +24,7 @@ environment_name: "vagrant"
 mariadb_host: "localhost"
 mariadb_port: "3306"
 mariadb_root_user: 'root'
-mariadb_root_pass: 'root'
+
 
 
 temp_dir: "/var/local/backups/drupal/temp"

--- a/files/d7_importdb.sh
+++ b/files/d7_importdb.sh
@@ -35,15 +35,15 @@ else
 
 
     # Get DB admin user
-    read -r -e -p "Enter MYSQL admin user: " -i "$D7_DBSU" D7_DBSU
+    read -r -e -p "Enter MYSQL admin user: " -i "$D7_DBSU" MY_DBSU
     # Get DB admin password
-    read -r -s -p "Enter MYSQL root password: " D7_DBSU_PASS
-    while ! mysql -u  "$D7_DBSU" -p"$D7_DBSU_PASS"  -e ";" ; do
-	read -r -s -p "Can't connect, please retry: " D7_DBSU_PASS
+    read -r -s -p "Enter MYSQL root password: " MY_DBSU_PASS
+    while ! mysql -u  "$MY_DBSU" -p"$MY_DBSU_PASS"  -e ";" ; do
+	read -r -s -p "Can't connect, please retry: " MY_DBSU_PASS
     done
     
     ## Create the Drupal database
-    sudo -u apache drush -y sql-create --db-su="$D7_DBSU" --db-su-pw="$D7_DBSU_PASS" -r "$SITEPATH/drupal" || exit 1;
+    sudo -u apache drush -y sql-create --db-su="$MY_DBSU" --db-su-pw="$MY_DBSU_PASS" -r "$SITEPATH/drupal" || exit 1;
 fi
 
 ## Load sql-dump to local DB

--- a/files/d7_init.sh
+++ b/files/d7_init.sh
@@ -38,6 +38,11 @@ while  [ -z "$MY_DBSU_PASS" ] || ! mysql --user="$MY_DBSU" --password="$MY_DBSU_
     read -r -s -p "Can't connect, please retry: " MY_DBSU_PASS
 done
 
+echo
+echo
+echo "SHALL WE BUILD A SITE?"
+echo
+
 # Generate Drupal DB password
 DBPSSWD=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 12 | head -n 1)
 
@@ -85,8 +90,8 @@ read -r -d '' SETTINGSPHP <<- EOF
       'database' => 'drupal_${SITE}_${ENV_NAME}',
       'username' => '$SITE',
       'password' => '$DBPSSWD',
-      'host' => '$DBHOST',
-      'port' => '$DBPORT',
+      'host' => '$MY_DBHOST',
+      'port' => '$MY_DBPORT',
       'driver' => 'mysql',
       'prefix' => '',
     ),

--- a/files/d7_init.sh
+++ b/files/d7_init.sh
@@ -40,7 +40,7 @@ done
 
 echo
 echo
-echo "SHALL WE BUILD A SITE?"
+echo "Let's build a site!"
 echo
 
 # Generate Drupal DB password

--- a/files/d7_init.sh
+++ b/files/d7_init.sh
@@ -20,11 +20,15 @@ if [[ -e "$SITEPATH" ]]; then
     exit 1
 fi
 
-# Get mysql host
+
+
+# Get external host suffix (rev proxy, ngrok, etc)
+read -r -e -p "Enter host suffix (e.g. lib.ou.edu): " -i "$D7_HOST_SUFFIX" MY_HOST_SUFFIX 
+
+# Get mysql host 
 read -r -e -p "Enter MYSQL host name: " -i "$D7_DBHOST" DBHOST
-# Get mysql host
+# Get mysql port
 read -r -e -p "Enter MYSQL host port: " -i "$D7_DBPORT" DBPORT
-echo
 
 # Get DB admin user
 read -r -e -p "Enter MYSQL admin user: " -i "$D7_DBSU" DBSU
@@ -90,8 +94,8 @@ read -r -d '' SETTINGSPHP <<- EOF
 );
 
 ## Set public-facing hostname.
-\$base_url = 'https://${SITE}.${D7_HOST_SUFFIX}';
-\$cookie_domain = '${SITE}.${D7_HOST_SUFFIX}';
+\$base_url = 'https://${SITE}.${MY_HOST_SUFFIX}';
+\$cookie_domain = '${SITE}.${MY_HOST_SUFFIX}';
 
 EOF
 

--- a/files/d7_init.sh
+++ b/files/d7_init.sh
@@ -26,16 +26,16 @@ fi
 read -r -e -p "Enter host suffix (e.g. lib.ou.edu): " -i "$D7_HOST_SUFFIX" MY_HOST_SUFFIX 
 
 # Get mysql host 
-read -r -e -p "Enter MYSQL host name: " -i "$D7_DBHOST" DBHOST
+read -r -e -p "Enter MYSQL host name: " -i "$D7_DBHOST" MY_DBHOST
 # Get mysql port
-read -r -e -p "Enter MYSQL host port: " -i "$D7_DBPORT" DBPORT
+read -r -e -p "Enter MYSQL host port: " -i "$D7_DBPORT" MY_DBPORT
 
 # Get DB admin user
-read -r -e -p "Enter MYSQL admin user: " -i "$D7_DBSU" DBSU
+read -r -e -p "Enter MYSQL admin user: " -i "$D7_DBSU" MY_DBSU
 # Get DB admin password
-read -r -s -p "Enter MYSQL root password: " D7_DBSU_PASS
-while ! mysql -u "$D7_DBSU" -p"$D7_DBSU_PASS"  -e ";" ; do
-    read -r -s -p "Can't connect, please retry: " D7_DBSU_PASS
+read -r -s -p "Enter MYSQL root password: " MY_DBSU_PASS
+while  [ -z "$MY_DBSU_PASS" ] || ! mysql --user="$MY_DBSU" --password="$MY_DBSU_PASS"  -e ";" ; do
+    read -r -s -p "Can't connect, please retry: " MY_DBSU_PASS
 done
 
 # Generate Drupal DB password
@@ -104,7 +104,7 @@ sudo -u apache echo "$SETTINGSPHP"| sudo -u apache tee -a "$SITEPATH/default/set
 sudo -u apache chmod 444 "$SITEPATH/default/settings.php"
 
 ## Create the Drupal database
-sudo -u apache drush -y sql-create --db-su="${D7_DBSU}" --db-su-pw="$D7_DBSU_PASS" -r "$SITEPATH/drupal" || exit 1;
+sudo -u apache drush -y sql-create --db-su="${MY_DBSU}" --db-su-pw="$MY_DBSU_PASS" -r "$SITEPATH/drupal" || exit 1;
 
 ## Do the Drupal install
 sudo -u apache drush -y -r "$SITEPATH/drupal" site-install --site-name="$SITE" || exit 1;


### PR DESCRIPTION
This PR straightens out the the database variable names and consistently uses `MY_` prefix for local variables. 
## Motivation and Context

Fixes a bug where install was using default var instead of overridden one. 
Based on PR #32 .
## How Has This Been Tested?

Successful init, sync, and import of sites with default and non-default database settings. 
