### PR TITLE
Set SELinux to allow apache to connect to ldap

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -12,13 +12,12 @@
   - php-gd
   - php-drush-drush
   - mariadb
-
-
+- name: Set SELinux to allow apache to connect to ldap servers
+  command: setsebool -P httpd_can_connect_ldap on
 - name: Add config include to http.conf
   lineinfile:
     dest: /etc/httpd/conf/httpd.conf
     line: "IncludeOptional \"/srv/*/etc/*.conf\""
-    
 - name: Ensure /etc/profile.d/d7-ops.sh exists
   file:
     path: /etc/profile.d/d7-ops.sh


### PR DESCRIPTION
Set SELinux to allow apache to connect to ldap servers

```
sudo setsebool -P httpd_can_connect_ldap on
```
## Motivation and Context

This role doesn't allow the ldap module to work out of the box, which is a very common use case
https://github.com/OULibraries/ansible-role-d7/issues/35
## How Has This Been Tested?

I applied this role to a broken box and made it happy
