### PR TITLE
Add support for keeping and loading makefile in $SITEPATH/etc

### DIFF
--- a/files/d7_make.sh
+++ b/files/d7_make.sh
@@ -6,13 +6,15 @@ source /opt/d7/etc/d7_conf.sh
 
 ## Don't edit below here.
 # Require arguments
-if [ ! -z "$1" ] && [ ! -z "$2" ]
-then
-  SITEPATH=$1
-  MAKEFILE=$2
-  echo "Deploying $MAKEFILE to $SITEPATH"
-else
-  echo "Requires site path (eg. /srv/sample) and makefile as argument"
+if [ ! -z "$1" ] && [ ! -z "$2" ]; then
+    SITEPATH=$1
+    MAKEFILE=$2
+    echo "Deploying $MAKEFILE to $SITEPATH"
+elif [ ! -z "$1" ]; then
+    SITEPATH=$1
+    MAKEFILE="file://$SITEPATH/etc/$(basename $SITEPATH).make"
+else 
+  echo "Requires at least a site path (eg. /srv/sample)"
   exit 1;
 fi
 

--- a/files/d7_make.sh
+++ b/files/d7_make.sh
@@ -27,8 +27,15 @@ d7_dump.sh "$SITEPATH" || exit 1;
 ## Delete build dir if it's there
 sudo -u apache rm -rf "$SITEPATH/drupal_build"
 
+# Make sure etc exists
+sudo -u apache mkdir -p "$SITEPATH/etc"
+
+# get our makefile 
+(cd "$SITEPATH/etc" &&  curl -O "$MAKEFILE")
+MY_MAKEFILE=$( basename "$MAKEFILE")
+
 ## Build from drush make or die
-sudo -u apache drush -y --working-copy make "$MAKEFILE" "$SITEPATH/drupal_build" || exit 1;
+sudo -u apache drush -y --working-copy make "${SITEPATH}/etc/${MY_MAKEFILE}" "$SITEPATH/drupal_build" || exit 1;
 
 ## Delete default site in the build
 sudo -u apache rm -rf "$SITEPATH/drupal_build/sites/default"

--- a/files/d7_make.sh
+++ b/files/d7_make.sh
@@ -46,10 +46,10 @@ if [ ! MAKEURI == "file://${MY_MAKEFILE}" ]; then
 
     # Backup old files if we have them
     [ -f $MY_MAKEFILE ] && cp -v "$MY_MAKEFILE" "${MY_MAKEFILE}.bak"
-    [ -f "${MY_MAKEFILE}.url" ] && cp -v "$MY_MAKEFILE" "${MY_MAKEFILE}.uri.bak"
+    [ -f "${MY_MAKEFILE}.uri" ] && cp -v "$MY_MAKEFILE" "${MY_MAKEFILE}.uri.bak"
 
     # Get a new copy of the make file
-    echo "$MAKEURI" > $SITEPATH/etc/site.make.uri
+    echo "$MAKEURI" > "${MY_MAKEFILE}.uri"
     (cd "$SITEPATH/etc" &&  curl "$MAKEURI"  -o "$MY_MAKEFILE")
 fi
 

--- a/files/d7_make.sh
+++ b/files/d7_make.sh
@@ -40,17 +40,21 @@ sudo -u apache rm -rf "$SITEPATH/drupal_build"
 # Make sure etc exists
 sudo -u apache mkdir -p "$SITEPATH/etc"
 
-# Backup the file we might be overwriting 
-[ -f $MY_MAKEFILE ] && cp -v "$MY_MAKEFILE" "${MY_MAKEFILE}.bak"
 
 # Download makefile if it isn't the one we already have
 if [ ! MAKEURI == "file://${MY_MAKEFILE}" ]; then
+
+    # Backup old files if we have them
+    [ -f $MY_MAKEFILE ] && cp -v "$MY_MAKEFILE" "${MY_MAKEFILE}.bak"
+    [ -f "${MY_MAKEFILE}.url" ] && cp -v "$MY_MAKEFILE" "${MY_MAKEFILE}.uri.bak"
+
+    # Get a new copy of the make file
     echo "$MAKEURI" > $SITEPATH/etc/site.make.uri
     (cd "$SITEPATH/etc" &&  curl "$MAKEURI"  -o "$MY_MAKEFILE")
 fi
 
 ## Build from drush make or die
-sudo -u apache drush -y --working-copy make "${MAKEURI}" "$SITEPATH/drupal_build" || exit 1;
+sudo -u apache drush -y --working-copy make "${MY_MAKEFILE}" "$SITEPATH/drupal_build" || exit 1;
 
 
 ## Delete default site in the build

--- a/files/d7_make.sh
+++ b/files/d7_make.sh
@@ -9,7 +9,7 @@ source /opt/d7/etc/d7_conf.sh
 # Require arguments
 if [ -z "$1" ]; then
     echo "Usage: d7_make.sh $SITEPATH [$MAKEURI]"
-    echo "If option $MAKEURI argument is not specified, a cached Makefile will be used"
+    echo "If optional \$MAKEURI argument is not specified, a cached Makefile will be used"
     exit 1;
 fi
 


### PR DESCRIPTION
- curls makefile from remote url to /etc
- runs against makefile in etc if no url is specified. 
- assumes that all makefiles are specified by URL (file:// urls work)
## Motivation and Context

Tracks which makefile was last used to build the site and allows for import based on that file.
## How Has This Been Tested?

D7 make with makefile specified and omitted. 
