### PR TITLE
d7_sync.sh should default to original behavior when only two arguments are provided.

### DIFF
--- a/files/d7_sync.sh
+++ b/files/d7_sync.sh
@@ -5,14 +5,21 @@ PATH=/opt/d7/bin:/usr/local/bin:/usr/bin:/bin:/sbin:$PATH
 source /opt/d7/etc/d7_conf.sh
 
 ## Require arguments
-if [ ! -z "$1" ] && [ ! -z "$2" ] && [ ! -z "$3" ]
+if [ ! -z "$1" ] && [ ! -z "$2" ]
 then
-  ORIGIN_SITEPATH=$1
+  SITEPATH=$1
   SRCHOST=$2
-  SITEPATH=$3
-  echo "Syncing $ORIGIN_SITEPATH content from $SRCHOST to local $SITEPATH"
+
+  if [-z "$3" ]; then
+      ORIGIN_SITEPATH=$3 
+  else
+      ORIGIN_SITEPATH=$SITEPATH
+  fi
+
+  echo "Syncing to SITEPATH content from $SRCHOST at $SITEPATH"
 else
-  echo "Requires site path (eg. /srv/sample), source host, and new site path as arguments"
+    echo "Usage: d7_synch.sh $SITEPATH $SRCHOST [$ORIGIN_SITEPATH]"
+    echo "$ORIGIN_SITEPATH is optional if it matches the local $SITEPATH"
   exit 1;
 fi
 

--- a/files/d7_sync.sh
+++ b/files/d7_sync.sh
@@ -16,9 +16,9 @@ then
       ORIGIN_SITEPATH=$SITEPATH
   fi
 
-  echo "Syncing to local path $SITEPATH  from $SRCHOST path $ORIGIN_SITEPATH"
+  echo "Syncing to local path $SITEPATH from $SRCHOST path $ORIGIN_SITEPATH"
 else
-    echo "Usage: d7_synch.sh \$SITEPATH \$SRCHOST [\$ORIGIN_SITEPATH]"
+    echo "Usage: d7_sync.sh \$SITEPATH \$SRCHOST [\$ORIGIN_SITEPATH]"
     echo "\$ORIGIN_SITEPATH is optional if it matches the local \$SITEPATH"
   exit 1;
 fi

--- a/files/d7_sync.sh
+++ b/files/d7_sync.sh
@@ -57,13 +57,14 @@ echo "Placing synced files."
 sudo rm -rf "$SITEPATH/default/files_bak"
 sudo mv "$SITEPATH/default/files" "$SITEPATH/default/files_bak"
 sudo mv "$SITEPATH/default/files_sync" "$SITEPATH/default/files"
+echo
+echo
+
 
 ## Perform sql-dump on source host
+echo "Dumping database for ${ORIGIN_SITEPATH} at ${SRCHOST}"
 ssh -A "$SRCHOST" drush -r "$ORIGIN_SITEPATH/drupal" sql-dump --result-file="$ORIGIN_SITEPATH/db/drupal_${ORIGIN_SITE}_sync.sql"
 
-## Sync sql-dump
+## Sync sql-dump to localhost and import
 rsync --omit-dir-times "$SRCHOST:$ORIGIN_SITEPATH/db/drupal_${ORIGIN_SITE}_sync.sql" "$SITEPATH/db/"
-
-
-## Import sql dump
 d7_importdb.sh "$SITEPATH" "$SITEPATH/db/drupal_${ORIGIN_SITE}_sync.sql" || exit 1;

--- a/files/d7_sync.sh
+++ b/files/d7_sync.sh
@@ -10,16 +10,16 @@ then
   SITEPATH=$1
   SRCHOST=$2
 
-  if [-z "$3" ]; then
+  if [ ! -z "$3" ]; then
       ORIGIN_SITEPATH=$3 
   else
       ORIGIN_SITEPATH=$SITEPATH
   fi
 
-  echo "Syncing to SITEPATH content from $SRCHOST at $SITEPATH"
+  echo "Syncing to local path $SITEPATH  from $SRCHOST path $ORIGIN_SITEPATH"
 else
-    echo "Usage: d7_synch.sh $SITEPATH $SRCHOST [$ORIGIN_SITEPATH]"
-    echo "$ORIGIN_SITEPATH is optional if it matches the local $SITEPATH"
+    echo "Usage: d7_synch.sh \$SITEPATH \$SRCHOST [\$ORIGIN_SITEPATH]"
+    echo "\$ORIGIN_SITEPATH is optional if it matches the local \$SITEPATH"
   exit 1;
 fi
 


### PR DESCRIPTION
Usage is now `d7_sync.sh $SITEPATH $SRCHOST [$ORIGIN_SITEPATH]` 
if `$ORIGIN_SITEPATH` is omitted, `$SITEPATH` will be used for both values. 
## Motivation and Context

Restores original two-argument behavior in most common use case, reducing the number of arguments usually required. Closes #42
## How Has This Been Tested?
- successful `d7_synch.sh /srv/libraries lib-53...` on vagrant vm
- successful `d7_synch.sh /srv/libraries0 lib-53... /srv/libraries` on vagrant vm
