### PR TITLE
Add one-command migrate site script.

### DIFF
--- a/files/d7_migrate.sh
+++ b/files/d7_migrate.sh
@@ -10,36 +10,30 @@ then
   SITEPATH=$1
   SRCHOST=$2
   ORIGIN_SITEPATH=$3 
-
 else
     echo "Usage: d7_migrate.sh \$SITEPATH \$SRCHOST \$ORIGIN_SITEPATH"
-
-  exit 1;
+    exit 1;
 fi
 
-## Grab the basename of the NEW site to use in a few places.
-SITE=$(basename "$SITEPATH")
-ORIGIN_SITE=$(basename "$ORIGIN_SITEPATH")
-
 ## Init site if it doesn't exist
-if [[ ! -e $SITEPATH ]]; then
+if [  -e "$SITEPATH" ]; then
     echo "A site alreay exists at $SITEPATH, try using sync."
     exit 1;
 fi
 
 # Build an empty site
-d7_init.sh $SITEPATH  || exit 1
+d7_init.sh "$SITEPATH"  || exit 1
 
 # Copy make files
 for file in "site.make" "site.make.uri" ; do
-    scp "$SRCHOST:$ORIGIN_SITEPATH/etc/${file}" "$SITEPATH/etc/${file"
+    scp "$SRCHOST:$ORIGIN_SITEPATH/etc/${file}" "$SITEPATH/etc/${file}"
 done
 
 # Install modules and themes
-d7_make.sh $SITEPATH || exit 1
+d7_make.sh "$SITEPATH" || exit 1
 
 # sync files and db
-d7_sync.sh $SITEPATH $SRCHOST $ORIGIN_SITEPATH || exit 1
+d7_sync.sh "$SITEPATH" "$SRCHOST" "$ORIGIN_SITEPATH" || exit 1
 
 
 

--- a/files/d7_migrate.sh
+++ b/files/d7_migrate.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+## Sync Drupal files & DB from source host
+PATH=/opt/d7/bin:/usr/local/bin:/usr/bin:/bin:/sbin:$PATH
+
+source /opt/d7/etc/d7_conf.sh
+
+## Require arguments
+if [ ! -z "$1" ] && [ ! -z "$2" ] && [ ! -z "$2" ]
+then
+  SITEPATH=$1
+  SRCHOST=$2
+  ORIGIN_SITEPATH=$3 
+
+else
+    echo "Usage: d7_migrate.sh \$SITEPATH \$SRCHOST \$ORIGIN_SITEPATH"
+
+  exit 1;
+fi
+
+## Grab the basename of the NEW site to use in a few places.
+SITE=$(basename "$SITEPATH")
+ORIGIN_SITE=$(basename "$ORIGIN_SITEPATH")
+
+## Init site if it doesn't exist
+if [[ ! -e $SITEPATH ]]; then
+    echo "A site alreay exists at $SITEPATH, try using sync."
+    exit 1;
+fi
+
+# Build an empty site
+d7_init.sh $SITEPATH  || exit 1
+
+# Copy make files
+for file in "site.make" "site.make.uri" ; do
+    scp "$SRCHOST:$ORIGIN_SITEPATH/etc/${file}" "$SITEPATH/etc/${file"
+done
+
+# Install modules and themes
+d7_make.sh $SITEPATH || exit 1
+
+# sync files and db
+d7_sync.sh $SITEPATH $SRCHOST $ORIGIN_SITEPATH || exit 1
+
+
+

--- a/files/d7_migrate.sh
+++ b/files/d7_migrate.sh
@@ -15,18 +15,17 @@ else
     exit 1;
 fi
 
-## Init site if it doesn't exist
 if [  -e "$SITEPATH" ]; then
     echo "A site alreay exists at $SITEPATH, try using sync."
     exit 1;
 fi
 
-# Build an empty site
+# Build an empty site 
 d7_init.sh "$SITEPATH"  || exit 1
 
-# Copy make files
+echo "Copying makefiles!"
 for file in "site.make" "site.make.uri" ; do
-    scp "$SRCHOST:$ORIGIN_SITEPATH/etc/${file}" "$SITEPATH/etc/${file}"
+    scp "$SRCHOST:$ORIGIN_SITEPATH/etc/${file}" "$SITEPATH/etc/${file}" || exit 1
 done
 
 # Install modules and themes

--- a/tasks/assets.yml
+++ b/tasks/assets.yml
@@ -17,12 +17,12 @@
     group: wheel
   with_items:
       - d7_clean.sh
-      - d7_clone.sh
       - d7_dump.sh
       - d7_httpd_conf.sh
       - d7_init.sh
       - d7_importdb.sh
       - d7_make.sh
+      - d7_migrate.sh
       - d7_sync.sh
       - d7_update.sh
   tags:

--- a/tasks/assets.yml
+++ b/tasks/assets.yml
@@ -17,6 +17,7 @@
     group: wheel
   with_items:
       - d7_clean.sh
+      - d7_clone.sh
       - d7_dump.sh
       - d7_httpd_conf.sh
       - d7_init.sh


### PR DESCRIPTION
This adds a d7_migrate.sh script that does init+make+sync to copy a site with a single command. 
## Motivation and Context

Closes #44
## How Has This Been Tested?

successful copy of libraries from test to vagrant
