### PR TITLE
Become apache for most operations on Drupal files. 

### DIFF
--- a/files/d7_clean.sh
+++ b/files/d7_clean.sh
@@ -30,14 +30,14 @@ then
   echo "DROP DATABASE \`drupal_${SITE}_${ENV_NAME}\`" | sudo -u apache drush sql-cli -r "$SITEPATH/drupal"
 
   ## Change 444 files to 644
-  sudo chmod 644 "$SITEPATH/default/settings.php"
-  sudo chmod 644 "$SITEPATH/default/files/.htaccess"
+  sudo -u apache chmod 644 "$SITEPATH/default/settings.php"
+  sudo -u apache chmod 644 "$SITEPATH/default/files/.htaccess"
 
   ## Remove the content
   ## /srv/libraries1/default isn't supposed to be writeable, so we need
   ## to do some things as root
   echo "Deleting site files."
-  sudo  rm -rf "$SITEPATH"
+  sudo -u apache  rm -rf "$SITEPATH"
 
   sudo systemctl restart httpd
 fi

--- a/files/d7_httpd_conf.sh
+++ b/files/d7_httpd_conf.sh
@@ -28,7 +28,7 @@ sudo -u apache mkdir "$SITEPATH/etc"
 sudo -u apache sh -c "sed "s/__SITE_DIR__/$SITE/g" /opt/d7/etc/d7_init_httpd_template > $SITEPATH/etc/srv_$SITE.conf" || exit 1;
 sudo -u apache sh -c "sed -i "s/__SITE_NAME__/$SITE/g" $SITEPATH/etc/srv_$SITE.conf" || exit 1;
 
-## Allow apache to read it's config
+## Allow apache to read its config
 sudo semanage fcontext -a -t httpd_sys_content_t  "$SITEPATH/etc(/.*)?" || exit 1;
 sudo restorecon -R "$SITEPATH/etc" || exit 1;
 

--- a/files/d7_httpd_conf.sh
+++ b/files/d7_httpd_conf.sh
@@ -28,6 +28,7 @@ sudo -u apache mkdir "$SITEPATH/etc"
 sudo -u apache sh -c "sed "s/__SITE_DIR__/$SITE/g" /opt/d7/etc/d7_init_httpd_template > $SITEPATH/etc/srv_$SITE.conf" || exit 1;
 sudo -u apache sh -c "sed -i "s/__SITE_NAME__/$SITE/g" $SITEPATH/etc/srv_$SITE.conf" || exit 1;
 
+## Allow apache to read it's config
 sudo semanage fcontext -a -t httpd_sys_content_t  "$SITEPATH/etc(/.*)?" || exit 1;
 sudo restorecon -R "$SITEPATH/etc" || exit 1;
 

--- a/files/d7_init.sh
+++ b/files/d7_init.sh
@@ -47,8 +47,8 @@ echo
 DBPSSWD=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 12 | head -n 1)
 
 ## Make the parent directory
-sudo mkdir -p "$SITEPATH"
-sudo chmod 775 "$SITEPATH"
+sudo -u apache mkdir -p "$SITEPATH"
+sudo -u apache chmod 775 "$SITEPATH"
 sudo chown apache:apache "$SITEPATH"
 
 ## Grab the basename of the site to use in a few places.
@@ -65,7 +65,7 @@ sudo ls > /dev/null
 find "$SITEPATH/drupal" -type d -exec sudo -u apache chmod u=rwx,g=rx,o= '{}' \;
 find "$SITEPATH/drupal" -type f -exec sudo -u apache chmod u=rw,g=r,o= '{}' \;
 
-# Set SELinux or die
+# Set SELinux to allow Drupal to access files or die
 echo "Setting SELinux policy."
 sudo semanage fcontext -a -t httpd_sys_content_t  "$SITEPATH/drupal(/.*)?" || exit 1;
 sudo semanage fcontext -a -t httpd_sys_rw_content_t  "$SITEPATH/default/files(/.*)?" || exit 1
@@ -112,7 +112,7 @@ sudo -u apache chmod 444 "$SITEPATH/default/settings.php"
 sudo -u apache drush -y sql-create --db-su="${MY_DBSU}" --db-su-pw="$MY_DBSU_PASS" -r "$SITEPATH/drupal" || exit 1;
 
 ## Do the Drupal install
-sudo -u apache drush -y -r "$SITEPATH/drupal" site-install --site-name="$SITE" || exit 1;
+sudo  -u apache drush -y -r "$SITEPATH/drupal" site-install --site-name="$SITE" || exit 1;
 
 ## Apply the apache config
 d7_httpd_conf.sh "$SITEPATH" || exit 1;

--- a/files/d7_init.sh
+++ b/files/d7_init.sh
@@ -112,7 +112,7 @@ sudo -u apache chmod 444 "$SITEPATH/default/settings.php"
 sudo -u apache drush -y sql-create --db-su="${MY_DBSU}" --db-su-pw="$MY_DBSU_PASS" -r "$SITEPATH/drupal" || exit 1;
 
 ## Do the Drupal install
-sudo  -u apache drush -y -r "$SITEPATH/drupal" site-install --site-name="$SITE" || exit 1;
+sudo -u apache drush -y -r "$SITEPATH/drupal" site-install --site-name="$SITE" || exit 1;
 
 ## Apply the apache config
 d7_httpd_conf.sh "$SITEPATH" || exit 1;

--- a/files/d7_make.sh
+++ b/files/d7_make.sh
@@ -45,12 +45,12 @@ sudo -u apache mkdir -p "$SITEPATH/etc"
 if [ ! MAKEURI == "file://${MY_MAKEFILE}" ]; then
 
     # Backup old files if we have them
-    [ -f $MY_MAKEFILE ] && cp -v "$MY_MAKEFILE" "${MY_MAKEFILE}.bak"
-    [ -f "${MY_MAKEFILE}.uri" ] && cp -v "$MY_MAKEFILE" "${MY_MAKEFILE}.uri.bak"
+    [ -f $MY_MAKEFILE ] && sudo -u apache cp -v "$MY_MAKEFILE" "${MY_MAKEFILE}.bak"
+    [ -f "${MY_MAKEFILE}.uri" ] && sudo -u apache cp -v "$MY_MAKEFILE" "${MY_MAKEFILE}.uri.bak"
 
     # Get a new copy of the make file
-    echo "$MAKEURI" > "${MY_MAKEFILE}.uri"
-    (cd "$SITEPATH/etc" &&  curl "$MAKEURI"  -o "$MY_MAKEFILE")
+    echo "$MAKEURI"  | sudo -u apache tee  "${MY_MAKEFILE}.uri" > /dev/null
+    (cd "$SITEPATH/etc" &&  sudo -u apache curl "$MAKEURI"  -o "$MY_MAKEFILE")
 fi
 
 ## Build from drush make or die

--- a/files/d7_make.sh
+++ b/files/d7_make.sh
@@ -62,8 +62,8 @@ sudo -u apache rm -rf "$SITEPATH/drupal_build/sites/default"
 
 ## Set perms
 echo "Setting permissions of the new build."
-sudo find "$SITEPATH/drupal_build" -type d -exec chmod u=rwx,g=rx,o= '{}' \;
-sudo find "$SITEPATH/drupal_build" -type f -exec chmod u=rw,g=r,o= '{}' \;
+sudo -u apache find "$SITEPATH/drupal_build" -type d -exec chmod u=rwx,g=rx,o= '{}' \;
+sudo -u apache find "$SITEPATH/drupal_build" -type f -exec chmod u=rw,g=r,o= '{}' \;
 
 # Set SELinux or die
 echo "Setting SELinux policy of the new build."
@@ -72,8 +72,8 @@ sudo restorecon -R "$SITEPATH/drupal_build" || exit 1;
 
 ## Set perms
 echo "Setting permissions of default site."
-sudo find "$SITEPATH/default" -type d -exec chmod u=rwx,g=rx,o= '{}' \;
-sudo find "$SITEPATH/default" -type f -exec chmod u=rw,g=r,o= '{}' \;
+sudo -u apache find "$SITEPATH/default" -type d -exec chmod u=rwx,g=rx,o= '{}' \;
+sudo -u apache find "$SITEPATH/default" -type f -exec chmod u=rw,g=r,o= '{}' \;
 
 # Set SELinux or die
 echo "Setting SELinux policy of the default site."

--- a/files/d7_sync.sh
+++ b/files/d7_sync.sh
@@ -33,8 +33,8 @@ if [[ ! -e $SITEPATH ]]; then
 fi
 
 ## Make the sync directory
-sudo mkdir -p "$SITEPATH/default/files_sync"
-sudo chmod 777 "$SITEPATH/default/files_sync"
+sudo -u apache mkdir -p "$SITEPATH/default/files_sync"
+sudo -u apache chmod 777 "$SITEPATH/default/files_sync"
 
 ## Sync Files to writable directory (sudo would break ssh)
 RSOPTS="--verbose --recursive --links --devices --compress"
@@ -43,8 +43,8 @@ echo "Files synced."
 
 ## Set perms for sync directory
 echo "Setting permissions for synced files."
-sudo find "$SITEPATH/default/files_sync" -type d -exec chmod u=rwx,g=rx,o= '{}' \;
-sudo find "$SITEPATH/default/files_sync" -type f -exec chmod u=rw,g=r,o= '{}' \;
+sudo -u apache find "$SITEPATH/default/files_sync" -type d -exec chmod u=rwx,g=rx,o= '{}' \;
+sudo -u apache find "$SITEPATH/default/files_sync" -type f -exec chmod u=rw,g=r,o= '{}' \;
 sudo chown -R apache:apache "$SITEPATH/default/files_sync"
 echo "Setting SELinux for synced files."
 sudo semanage fcontext -a -t httpd_sys_rw_content_t  "$SITEPATH/default/files_sync(/.*)?" || exit 1
@@ -54,9 +54,9 @@ sudo restorecon -R "$SITEPATH/default" || exit 1;
 ## /srv/libraries1/default isn't supposed to be writeable, so we need
 ## to do some things as root.
 echo "Placing synced files."
-sudo rm -rf "$SITEPATH/default/files_bak"
-sudo mv "$SITEPATH/default/files" "$SITEPATH/default/files_bak"
-sudo mv "$SITEPATH/default/files_sync" "$SITEPATH/default/files"
+sudo -u apache rm -rf "$SITEPATH/default/files_bak"
+sudo -u apache mv "$SITEPATH/default/files" "$SITEPATH/default/files_bak"
+sudo -u apache mv "$SITEPATH/default/files_sync" "$SITEPATH/default/files"
 echo
 echo
 

--- a/files/d7_sync.sh
+++ b/files/d7_sync.sh
@@ -37,7 +37,7 @@ sudo -u apache mkdir -p "$SITEPATH/default/files_sync"
 sudo -u apache chmod 777 "$SITEPATH/default/files_sync"
 
 ## Sync Files to writable directory (sudo would break ssh)
-RSOPTS="--verbose --recursive --links --devices --compress"
+RSOPTS="--verbose --recursive --links  --compress"
 rsync  $RSOPTS  "$SRCHOST:$ORIGIN_SITEPATH/default/files/" "$SITEPATH/default/files_sync" ;
 echo "Files synced."
 


### PR DESCRIPTION
Big switch from `sudo` to `sudo -u apache`. 
## Motivation and Context

Drupal files will now live on an NFS server exporting shares with `root_squash` turned on, so operations performed as root against those files will fail. 
## How Has This Been Tested?

Successful cycle of:

```
d7_init.sh  /srv/libraries0
d7_make.sh  /srv/libraries0 https://raw.githubusercontent.com/OULibraries/d7-ops/master/make/libraries.make
d7_sync.sh  /srv/libraries0 lib-25 /srv/libraries
d7_clean.sh /srv/libraries0
```
