### PR TITLE
Write php.ini and apc.php with replace module instead of lineinfile

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -14,14 +14,14 @@
   replace:
     dest: /usr/share/pear/apc.php
     regexp: >
-      ^defaults\('ADMIN_USERNAME','apc'\);.*$
-    replace: "defaults('ADMIN_USERNAME','{{ apc_username }}');"
+      ^defaults\('ADMIN_USERNAME','apc'\);(.*)$
+    replace: defaults('ADMIN_USERNAME','{{ apc_username }}');\1
 - name: Set APC Password
   replace:
     dest: /usr/share/pear/apc.php
     regexp: >
-      ^defaults\('ADMIN_PASSWORD','password'\);.*$
-    replace: "defaults('ADMIN_PASSWORD','{{ apc_password }}');"
+      ^defaults\('ADMIN_PASSWORD','password'\);(.*)$
+    replace: defaults('ADMIN_PASSWORD','{{ apc_password }}');\1
 - name: Set upload_max_filesize
   replace:
     dest: /etc/php.ini
@@ -45,11 +45,11 @@
   lineinfile: 
     state: present
     dest: /etc/profile.d/d7-ops.sh
-    line: "'export PATH=/opt/d7/bin:$PATH'"
+    line: "export PATH=/opt/d7/bin:$PATH"
 - name: Add ops scripts to sudo secure_path
   replace:
     dest: /etc/sudoers
     regexp: >
       ^Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin$
-    replace: "'Defaults    secure_path = /opt/d7/bin:/sbin:/bin:/usr/sbin:/usr/bin'"
+    replace: 'Defaults    secure_path = /opt/d7/bin:/sbin:/bin:/usr/sbin:/usr/bin'
     validate: visudo -cf %s

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -15,13 +15,15 @@
     dest: /usr/share/pear/apc.php
     regexp: >
       ^defaults\('ADMIN_USERNAME','apc'\);(.*)$
-    replace: defaults('ADMIN_USERNAME','{{ apc_username }}');\1
+    replace: >
+      defaults('ADMIN_USERNAME','{{ apc_username }}');\1
 - name: Set APC Password
   replace:
     dest: /usr/share/pear/apc.php
     regexp: >
       ^defaults\('ADMIN_PASSWORD','password'\);(.*)$
-    replace: defaults('ADMIN_PASSWORD','{{ apc_password }}');\1
+    replace: >
+      defaults('ADMIN_PASSWORD','{{ apc_password }}');\1
 - name: Set upload_max_filesize
   replace:
     dest: /etc/php.ini

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -12,13 +12,23 @@
 - name: Set APC Username
   lineinfile:
     dest: /usr/share/pear/apc.php
-    regexp: ^defaults\('ADMIN_USERNAME','apc'\);
+    regexp: ^defaults\('ADMIN_USERNAME','apc'\);.*$
     line: "defaults('ADMIN_USERNAME','{{ apc_username }}');"
 - name: Set APC Password
   lineinfile:
     dest: /usr/share/pear/apc.php
-    regexp: ^defaults\('ADMIN_PASSWORD','password'\);
+    regexp: ^defaults\('ADMIN_PASSWORD','password'\);.*$
     line: "defaults('ADMIN_PASSWORD','{{ apc_password }}');"
+- name: Set upload_max_filesize
+  lineinfile:
+    dest: /etc/php.ini
+    regexp: ^upload_max_filesize = 2M$
+    line: "upload_max_filesize = 64M"
+- name: Set post_max_size
+  lineinfile:
+    dest: /etc/php.ini
+    regexp: ^post_max_size = 8M$
+    line: "post_max_size = 70M"
 - name: Ensure /etc/profile.d/d7-ops.sh exists
   file:
     path: /etc/profile.d/d7-ops.sh

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,5 +1,5 @@
 ---
-- name: Set SELinux exceptions for apache 
+- name: Set SELinux exceptions for apache
   command: "setsebool -P {{ item }} on"
   with_items:
   - httpd_can_connect_ldap
@@ -7,28 +7,33 @@
   - httpd_can_sendmail
 - name: Add config include to http.conf
   lineinfile:
+    state: present
     dest: /etc/httpd/conf/httpd.conf
     line: "IncludeOptional \"/srv/*/etc/*.conf\""
 - name: Set APC Username
-  lineinfile:
+  replace:
     dest: /usr/share/pear/apc.php
-    regexp: ^defaults\('ADMIN_USERNAME','apc'\);.*$
-    line: "defaults('ADMIN_USERNAME','{{ apc_username }}');"
+    regexp: >
+      ^defaults\('ADMIN_USERNAME','apc'\);.*$
+    replace: "defaults('ADMIN_USERNAME','{{ apc_username }}');"
 - name: Set APC Password
-  lineinfile:
+  replace:
     dest: /usr/share/pear/apc.php
-    regexp: ^defaults\('ADMIN_PASSWORD','password'\);.*$
-    line: "defaults('ADMIN_PASSWORD','{{ apc_password }}');"
+    regexp: >
+      ^defaults\('ADMIN_PASSWORD','password'\);.*$
+    replace: "defaults('ADMIN_PASSWORD','{{ apc_password }}');"
 - name: Set upload_max_filesize
-  lineinfile:
+  replace:
     dest: /etc/php.ini
-    regexp: ^upload_max_filesize = 2M$
-    line: "upload_max_filesize = 64M"
+    regexp: >
+      ^upload_max_filesize = 2M$
+    replace: "upload_max_filesize = 64M"
 - name: Set post_max_size
-  lineinfile:
+  replace:
     dest: /etc/php.ini
-    regexp: ^post_max_size = 8M$
-    line: "post_max_size = 70M"
+    regexp: >
+      ^post_max_size = 8M$
+    replace: "post_max_size = 70M"
 - name: Ensure /etc/profile.d/d7-ops.sh exists
   file:
     path: /etc/profile.d/d7-ops.sh
@@ -37,6 +42,14 @@
     owner: root
     group: root
 - name: Add ops scripts to path
-  lineinfile: "dest=/etc/profile.d/d7-ops.sh line='export PATH=/opt/d7/bin:$PATH'"
+  lineinfile: 
+    state: present
+    dest: /etc/profile.d/d7-ops.sh
+    line: "'export PATH=/opt/d7/bin:$PATH'"
 - name: Add ops scripts to sudo secure_path
-  lineinfile: "dest=/etc/sudoers state=present regexp='^Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin$' line='Defaults    secure_path = /opt/d7/bin:/sbin:/bin:/usr/sbin:/usr/bin' validate='visudo -cf %s'"
+  replace:
+    dest: /etc/sudoers
+    regexp: >
+      ^Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin$
+    replace: "'Defaults    secure_path = /opt/d7/bin:/sbin:/bin:/usr/sbin:/usr/bin'"
+    validate: visudo -cf %s


### PR DESCRIPTION
I think I found a bug in lineinfile when used with regexp. So I made some changes to fix the apc.php idempotency issues and added in some php.ini values while I was at it.  We probably need to make this change anywhere we're using lineinfile with regexp.
## Motivation and Context

https://github.com/OULibraries/ansible-role-d7/issues/48
https://github.com/OULibraries/ansible-role-d7/issues/58
## How Has This Been Tested?

a whole bunch of vagrant up.
