### PR TITLE
Remove broken precondition from d7_sync.sh

### DIFF
--- a/files/d7_sync.sh
+++ b/files/d7_sync.sh
@@ -42,7 +42,7 @@ if [[ ! -e $SITEPATH ]]; then
 fi
 
 ## Can't sync a nonexisting remote site
-if ssh -A d7.dev.web.ec2.internal [[ ! -e "${ORIGIN_SITEPATH}" ]] ; then 
+if ssh -A "${SRCHOST}" [[ ! -e "${ORIGIN_SITEPATH}" ]] ; then 
     echo "Can't find remote site at ${ORIGIN_SITEPATH}."
     exit 1
 fi

--- a/files/d7_sync.sh
+++ b/files/d7_sync.sh
@@ -41,11 +41,6 @@ if [[ ! -e $SITEPATH ]]; then
     d7_init.sh "$SITEPATH" || exit 1;
 fi
 
-## Can't sync a nonexisting remote site
-if ssh -A "${SRCHOST}" [[ ! -e "${ORIGIN_SITEPATH}" ]] ; then 
-    echo "Can't find remote site at ${ORIGIN_SITEPATH}."
-    exit 1
-fi
 
 ## Drupal default site dir is ~ 6770
 d7_perms.sh --sticky "$SITEPATH/default"


### PR DESCRIPTION
Removing broken precondition to restore working behavior. 
## Motivation and Context

Short term fix to prevent broken precondition from causing issues for people. 
Added issue #67 to document need for tests that work. 
## How Has This Been Tested?

Successful site sync after removal. 
