### PR TITLE
Terrible regexy fix for d7_cc.sh

### DIFF
--- a/files/d7_cc.sh
+++ b/files/d7_cc.sh
@@ -23,8 +23,14 @@ if [[ ! -e "$SITEPATH" ]] ;then
     exit 0
 fi
 
+# Kludging APC username and password from php file.
+APC_USER=$(cat /usr/share/pear/apc.php  | grep ^defaults.*USERNAME | grep -o \'.*\',\'.*\' | awk  'BEGIN { FS=","};  {print $2}')
+APC_USER=${APC_USER:1:-1}
+APC_PASS=$(cat /usr/share/pear/apc.php  | grep ^defaults.*PASSWORD | grep -o \'.*\',\'.*\' | awk  'BEGIN { FS=","};  {print $2}')
+APC_PASS=${APC_PASS:1:-1}
+
 echo "Clearing APC cache"
-curl --silent --basic --user "${APC_USER}:${APC_PASS}" "http://localhost/apc.php?SCOPE=A&SORT1=H&SORT2=D&COUNT=20&CC=1&OB=1" >/dev/null || exit 1;
+curl --silent --basic --user "${APC_USER}:${APC_PASS}" "http://localhost/apc.php?SCOPE=A&SORT1=H&SORT2=D&COUNT=20&CC=1&OB=1" >/dev/null|| exit 1;
 
 echo "Clearing Drupal caches for ${SITEPATH}."
 sudo -u apache drush -y cc all -r "$SITEPATH/drupal" || exit 1;

--- a/files/d7_cc.sh
+++ b/files/d7_cc.sh
@@ -30,7 +30,7 @@ APC_PASS=$(cat /usr/share/pear/apc.php  | grep ^defaults.*PASSWORD | grep -o \'.
 APC_PASS=${APC_PASS:1:-1}
 
 echo "Clearing APC cache"
-curl --silent --basic --user "${APC_USER}:${APC_PASS}" "http://localhost/apc.php?SCOPE=A&SORT1=H&SORT2=D&COUNT=20&CC=1&OB=1" >/dev/null|| exit 1;
+curl --silent --basic --user "${APC_USER}:${APC_PASS}" "http://localhost/apc.php?SCOPE=A&SORT1=H&SORT2=D&COUNT=20&CC=1&OB=1" >/dev/null || exit 1;
 
 echo "Clearing Drupal caches for ${SITEPATH}."
 sudo -u apache drush -y cc all -r "$SITEPATH/drupal" || exit 1;

--- a/templates/d7_conf.sh.j2
+++ b/templates/d7_conf.sh.j2
@@ -10,6 +10,3 @@ D7_DBHOST="{{ mariadb_host }}"
 D7_DBPORT="{{ mariadb_port }}"
 D7_DBSU="{{ mariadb_root_user}}"
 
-# APC credentials
-APC_USER="{{ apc_username }}"
-APC_PASS="{{ apc_password }}"


### PR DESCRIPTION
Bash out username and password for resetting APC.

This works, but is kind of terrible. 

@jsnshrmn , if you're amenable, I think I'd rather write a small cache-clearing script that returns the status as JSON that we can parse for the user, and make that a localhost only thing that can be curled without a password. 

Maybe something like #70.
## Motivation and Context

Does away with APC credentials in `/opt/d7/etc/d7_conf.sh`, reads them from config instead. This prevents the two files from getting out of sync.  
## How Has This Been Tested?

d7_cc.sh /srv/dev clears APC cache.
