### PR TITLE
Add PHP SOAP module.

### DIFF
--- a/tasks/yum.yml
+++ b/tasks/yum.yml
@@ -11,6 +11,7 @@
   - php-ldap
   - php-pear
   - php-gd
+  - php-soap
   - php-drush-drush
   - mariadb
   - gcc


### PR DESCRIPTION
Adds php-soap  to list of modules installed by yum
## Motivation and Context

The LabStats API is SOAP-based, so our LabStats Drupal module is SOAP based.  
## How Has This Been Tested?

Not yet tested. 
