### PR TITLE
Use rw selinux context for drupal files.

### DIFF
--- a/files/d7_httpd_conf.sh
+++ b/files/d7_httpd_conf.sh
@@ -36,7 +36,7 @@ sudo -u apache sh -c "sed "s/__SITE_DIR__/$SITE/g" /opt/d7/etc/d7_init_httpd_tem
 sudo -u apache sh -c "sed -i "s/__SITE_NAME__/$SITE/g" $SITEPATH/etc/srv_$SITE.conf" || exit 1;
 
 ## Allow apache to read its config
-sudo semanage fcontext -a -t httpd_sys_content_t  "$SITEPATH/etc(/.*)?" || exit 1;
+sudo semanage fcontext -a -t httpd_sys_rw_content_t  "$SITEPATH/etc(/.*)?" || exit 1;
 sudo restorecon -R "$SITEPATH/etc" || exit 1;
 
 ## Set perms

--- a/files/d7_perms.sh
+++ b/files/d7_perms.sh
@@ -53,7 +53,7 @@ fi
 echo "Setting ${POLICY} permissions on ${INPUTDIR}"
 
 ## Set SELinux context.  Useless over NFS/SMB.
-sudo semanage fcontext -a -t httpd_sys_content_t  "${INPUTDIR}(/.*)?"
+sudo semanage fcontext -a -t httpd_sys_rw_content_t  "${INPUTDIR}(/.*)?"
 sudo restorecon -R "${INPUTDIR}"
 
 ## Set perms. Try as apache first, then as self.


### PR DESCRIPTION
Switch selinux context from httpd_sys_content_t to httpd_sys_rw_content_t  because http_sys_content_t is readonly in CentOS 7
## Motivation and Context

The current context is incorrect and breaks various things. This is masked for sites on NFS volumes, where we're forcing the right context.  
## How Has This Been Tested?

Verified that d7_perms.sh  now sets correct context on local storage. 
