### PR TITLE
Let apache group members see inside /var/log/httpd

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -5,6 +5,12 @@
   - httpd_can_connect_ldap
   - httpd_can_network_connect
   - httpd_can_sendmail
+- name: Allow apache group to view httpd log files
+  file:
+    path: /var/log/httpd
+    owner: root
+    group: apache
+    mode: 750
 - name: Add config include to http.conf
   lineinfile:
     state: present

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -10,7 +10,7 @@
     path: /var/log/httpd
     owner: root
     group: apache
-    mode: 750
+    mode: 0750
 - name: Add config include to http.conf
   lineinfile:
     state: present


### PR DESCRIPTION
Set 0750 and apache group for /var/log/httpd
## Motivation and Context

Addresses #74.
## How Has This Been Tested?

/var/log/httpd has new permissions and log files are viewable by apache group members after run of playbook. 
