### PR TITLE
Make APC optional for dev environments

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,5 +25,8 @@ mariadb_host: "localhost"
 mariadb_port: "3306"
 mariadb_root_user: 'root'
 
+# Set to 0 to disable APC
+apc_enabled: "1"
+
 
 

--- a/tasks/assets.yml
+++ b/tasks/assets.yml
@@ -41,13 +41,13 @@
   with_items:
       - d7_daily.cron
 
-- name: Install apc.ini
-  copy:
+- name: Install apc.ini 
+  template:
+    src: apc.ini.j2
+    dest: /etc/php.d/apc.ini
     mode: 0644
     owner: root
     group: root
-    src: apc.ini
-    dest: /etc/php.d
 
 - name: Install apc.conf
   copy:

--- a/templates/apc.ini.j2
+++ b/templates/apc.ini.j2
@@ -1,5 +1,5 @@
 extension=apc.so
-apc.enabled=1
+apc.enabled={{ apc_enabled }}
 apc.ttl=7200
 apc.user_ttl=7200
 apc.gc_ttl=3600


### PR DESCRIPTION
- Make apc_enabled an optional parameter in apc.ini
- Set default to enabled. 
## Motivation and Context

Disabling apc in development environments makes for happier devs. 
## How Has This Been Tested?

Confirmed that setting apc_enabled to 0  in my-vars.yml disables APC and not doing that leaves it on. 
