### PR TITLE
Set server wide reverse proxy settings in /opt/d7/etc/d7_proxy.inc.php

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,5 +28,9 @@ mariadb_root_user: 'root'
 # Set to 0 to disable APC
 apc_enabled: "1"
 
+## List of reverse proxies to feed to Drupal. Neccessary mainly in
+## test and prod at aws
+# d7_proxies:
+#  - 127.0.0.1
 
 

--- a/files/d7_init.sh
+++ b/files/d7_init.sh
@@ -87,25 +87,13 @@ read -r -d '' SETTINGSPHP <<- EOF
 \$base_url = 'https://${SITE}.${MY_HOST_SUFFIX}';
 \$cookie_domain = '${SITE}.${MY_HOST_SUFFIX}';
 
+## Include reverse proxy config (empty if no proxy)
+include '/opt/d7/etc/d7_proxy.inc.php';
+
 EOF
 
 sudo -u apache cp "$SITEPATH/default/default.settings.php" "$SITEPATH/default/settings.php"
 sudo -u apache echo "$SETTINGSPHP"| sudo -u apache tee -a "$SITEPATH/default/settings.php" >/dev/null
-
-# Drupal reverse proxy block for settings.php
-read -r -d '' PROXYPHP <<- EOF
-
-$conf['reverse_proxy'] = TRUE;
-$conf['reverse_proxy_addresses'] = array('${D7_PROXY_IP}');
-$conf['reverse_proxy_header'] = 'HTTP_X_FORWARDED_FOR';
-
-EOF
-
-## Set reverse proxy IP if defined
-if [ -n "${D7_PROXY_IP}" ] ; then
-   echo "Set reverse proxy at ${D7_PROXY_IP}."
-   sudo -u apache echo "$PROXYPHP" | sudo -u apache tee -a "$SITEPATH/default/settings.php" >/dev/null
-fi
    
 ## Create the Drupal database
 sudo -u apache drush -y sql-create --db-su="${MY_DBSU}" --db-su-pw="$MY_DBSU_PASS" -r "$SITEPATH/drupal" || exit 1;

--- a/files/d7_init.sh
+++ b/files/d7_init.sh
@@ -92,6 +92,21 @@ EOF
 sudo -u apache cp "$SITEPATH/default/default.settings.php" "$SITEPATH/default/settings.php"
 sudo -u apache echo "$SETTINGSPHP"| sudo -u apache tee -a "$SITEPATH/default/settings.php" >/dev/null
 
+# Drupal reverse proxy block for settings.php
+read -r -d '' PROXYPHP <<- EOF
+
+$conf['reverse_proxy'] = TRUE;
+$conf['reverse_proxy_addresses'] = array('${D7_PROXY_IP}');
+$conf['reverse_proxy_header'] = 'HTTP_X_FORWARDED_FOR';
+
+EOF
+
+## Set reverse proxy IP if defined
+if [ -n "${D7_PROXY_IP}" ] ; then
+   echo "Set reverse proxy at ${D7_PROXY_IP}."
+   sudo -u apache echo "$PROXYPHP" | sudo -u apache tee -a "$SITEPATH/default/settings.php" >/dev/null
+fi
+   
 ## Create the Drupal database
 sudo -u apache drush -y sql-create --db-su="${MY_DBSU}" --db-su-pw="$MY_DBSU_PASS" -r "$SITEPATH/drupal" || exit 1;
 

--- a/tasks/assets.yml
+++ b/tasks/assets.yml
@@ -96,3 +96,13 @@
     owner: root
     group: wheel
     mode: 0444
+
+- name: Install reverse proxy config
+  template:
+    src: d7_proxy.inc.j2
+    dest: /opt/d7/etc/d7_proxy.inc.php
+    owner: apache
+    group: wheel
+    mode: 0444
+
+    

--- a/templates/d7_conf.sh.j2
+++ b/templates/d7_conf.sh.j2
@@ -7,7 +7,6 @@ ENV_NAME="{{ environment_name }}"
 # Public facing host name
 D7_HOST_SUFFIX="{{httpd_dn_suffix}}"
 
-
 # Default MySQL target
 D7_DBHOST="{{ mariadb_host }}"
 D7_DBPORT="{{ mariadb_port }}"

--- a/templates/d7_proxy.inc.j2
+++ b/templates/d7_proxy.inc.j2
@@ -1,8 +1,8 @@
 {% if d7_proxies is defined %}
 <?php
-
+## Configure Drupal reverse proxy
 $conf['reverse_proxy'] = TRUE;
-$conf['reverse_proxy_addresses'] = array( {%- for proxy_ip in d7_proxies -%} '{{ proxy_ip }}', {%- endfor %});
+$conf['reverse_proxy_addresses'] = array('{{ d7_proxies|join('\',\'') }}');
 $conf['reverse_proxy_header'] = 'HTTP_X_FORWARDED_FOR';
 
 {% endif %}

--- a/templates/d7_proxy.inc.j2
+++ b/templates/d7_proxy.inc.j2
@@ -1,0 +1,8 @@
+{% if d7_proxies is defined %}
+<?php
+
+$conf['reverse_proxy'] = TRUE;
+$conf['reverse_proxy_addresses'] = array( {%- for proxy_ip in d7_proxies -%} '{{ proxy_ip }}', {%- endfor %});
+$conf['reverse_proxy_header'] = 'HTTP_X_FORWARDED_FOR';
+
+{% endif %}


### PR DESCRIPTION
Configure optional server-wide reverse proxy settings (mainly adjusts which IP addresses show up in the flood table.)

Motivation and Context
----------------------
We use a reverse proxy, so we need to keep it from getting fail-banned when (for example) AD goes down. 

How Has This Been Tested?
-------------------------
Needs further testing
