### PR TITLE
Let users role set secure path via var.  Set default for it here.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ For more, see defaults/main.yml
 Dependencies
 ------------
 
-Requires OU Libraries centos7, mariadb, and apache2 roles. To install:
+Requires OU Libraries centos7, mariadb, apache2, and users roles. To install:
 ```
 ansible-galaxy install -r requirements.yml
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,5 +28,9 @@ mariadb_root_user: 'root'
 # Set to 0 to disable APC
 apc_enabled: "1"
 
+## List of reverse proxies to feed to Drupal. Neccessary mainly in
+## test and prod at aws
+# d7_proxies:
+#  - 127.0.0.1
 
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,13 +8,17 @@
 #  1) proper DNS entries
 #  2) a service like ngrok
 httpd_dn_suffix: 'example.com'
+
 ## Your email address
 email: 'user@example.com'
+
 ## The hostnames of the sites you will build.
 #sites: ['drupal-dev1', 'drupal-dev2']
+
 ## Let's encrypt cert paths
 #httpd_cert_path: '/vagrant/letsencrypt/etc/live/'
 #httpd_key_path: '/vagrant/letsencrypt/etc/live/'
+
 ## Self-signed cert paths
 httpd_cert_path: '/etc/pki/tls/certs/'
 httpd_key_path: '/etc/pki/tls/private/'
@@ -25,5 +29,5 @@ mariadb_host: "localhost"
 mariadb_port: "3306"
 mariadb_root_user: 'root'
 
-
-
+# Setting secure path makes sudo work as desired
+users_secure_path: '/opt/php/bin:/opt/d7/bin:/sbin:/bin:/usr/sbin:/usr/bin'

--- a/files/d7_init.sh
+++ b/files/d7_init.sh
@@ -87,25 +87,13 @@ read -r -d '' SETTINGSPHP <<- EOF
 \$base_url = 'https://${SITE}.${MY_HOST_SUFFIX}';
 \$cookie_domain = '${SITE}.${MY_HOST_SUFFIX}';
 
+## Include reverse proxy config (empty if no proxy)
+include '/opt/d7/etc/d7_proxy.inc.php';
+
 EOF
 
 sudo -u apache cp "$SITEPATH/default/default.settings.php" "$SITEPATH/default/settings.php"
 sudo -u apache echo "$SETTINGSPHP"| sudo -u apache tee -a "$SITEPATH/default/settings.php" >/dev/null
-
-# Drupal reverse proxy block for settings.php
-read -r -d '' PROXYPHP <<- EOF
-
-$conf['reverse_proxy'] = TRUE;
-$conf['reverse_proxy_addresses'] = array('${D7_PROXY_IP}');
-$conf['reverse_proxy_header'] = 'HTTP_X_FORWARDED_FOR';
-
-EOF
-
-## Set reverse proxy IP if defined
-if [ -n "${D7_PROXY_IP}" ] ; then
-   echo "Set reverse proxy at ${D7_PROXY_IP}."
-   sudo -u apache echo "$PROXYPHP" | sudo -u apache tee -a "$SITEPATH/default/settings.php" >/dev/null
-fi
    
 ## Create the Drupal database
 sudo -u apache drush -y sql-create --db-su="${MY_DBSU}" --db-su-pw="$MY_DBSU_PASS" -r "$SITEPATH/drupal" || exit 1;

--- a/files/d7_init.sh
+++ b/files/d7_init.sh
@@ -92,6 +92,21 @@ EOF
 sudo -u apache cp "$SITEPATH/default/default.settings.php" "$SITEPATH/default/settings.php"
 sudo -u apache echo "$SETTINGSPHP"| sudo -u apache tee -a "$SITEPATH/default/settings.php" >/dev/null
 
+# Drupal reverse proxy block for settings.php
+read -r -d '' PROXYPHP <<- EOF
+
+$conf['reverse_proxy'] = TRUE;
+$conf['reverse_proxy_addresses'] = array('${D7_PROXY_IP}');
+$conf['reverse_proxy_header'] = 'HTTP_X_FORWARDED_FOR';
+
+EOF
+
+## Set reverse proxy IP if defined
+if [ -n "${D7_PROXY_IP}" ] ; then
+   echo "Set reverse proxy at ${D7_PROXY_IP}."
+   sudo -u apache echo "$PROXYPHP" | sudo -u apache tee -a "$SITEPATH/default/settings.php" >/dev/null
+fi
+   
 ## Create the Drupal database
 sudo -u apache drush -y sql-create --db-su="${MY_DBSU}" --db-su-pw="$MY_DBSU_PASS" -r "$SITEPATH/drupal" || exit 1;
 

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,9 +1,17 @@
 ---
-# fetch OULibraries.centos7 from github
+
 - src: https://github.com/OULibraries/ansible-role-centos7
   version: master
   name: OULibraries.centos7
-# fetch OULibraries.apache2 from github
+
 - src: https://github.com/OULibraries/ansible-role-apache2
   version: master
   name: OULibraries.apache2
+
+- src: https://github.com/OULibraries/ansible-role-mariadb
+  version: master
+  name: OULibraries.mariadb
+
+- src: https://github.com/OULibraries/ansible-role-users
+  version: master
+  name: OULibraries.users

--- a/tasks/assets.yml
+++ b/tasks/assets.yml
@@ -96,3 +96,13 @@
     owner: root
     group: wheel
     mode: 0444
+
+- name: Install reverse proxy config
+  template:
+    src: d7_proxy.inc.j2
+    dest: /opt/d7/etc/d7_proxy.inc.php
+    owner: apache
+    group: wheel
+    mode: 0444
+
+    

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -48,10 +48,3 @@
     state: present
     dest: /etc/profile.d/d7-ops.sh
     line: "export PATH=/opt/d7/bin:$PATH"
-- name: Add ops scripts to sudo secure_path
-  replace:
-    dest: /etc/sudoers
-    regexp: >
-      ^Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin$
-    replace: 'Defaults    secure_path = /opt/d7/bin:/sbin:/bin:/usr/sbin:/usr/bin'
-    validate: visudo -cf %s

--- a/templates/d7_conf.sh.j2
+++ b/templates/d7_conf.sh.j2
@@ -7,7 +7,6 @@ ENV_NAME="{{ environment_name }}"
 # Public facing host name
 D7_HOST_SUFFIX="{{httpd_dn_suffix}}"
 
-
 # Default MySQL target
 D7_DBHOST="{{ mariadb_host }}"
 D7_DBPORT="{{ mariadb_port }}"

--- a/templates/d7_proxy.inc.j2
+++ b/templates/d7_proxy.inc.j2
@@ -1,8 +1,8 @@
 {% if d7_proxies is defined %}
 <?php
-
+## Configure Drupal reverse proxy
 $conf['reverse_proxy'] = TRUE;
-$conf['reverse_proxy_addresses'] = array( {%- for proxy_ip in d7_proxies -%} '{{ proxy_ip }}', {%- endfor %});
+$conf['reverse_proxy_addresses'] = array('{{ d7_proxies|join('\',\'') }}');
 $conf['reverse_proxy_header'] = 'HTTP_X_FORWARDED_FOR';
 
 {% endif %}

--- a/templates/d7_proxy.inc.j2
+++ b/templates/d7_proxy.inc.j2
@@ -1,0 +1,8 @@
+{% if d7_proxies is defined %}
+<?php
+
+$conf['reverse_proxy'] = TRUE;
+$conf['reverse_proxy_addresses'] = array( {%- for proxy_ip in d7_proxies -%} '{{ proxy_ip }}', {%- endfor %});
+$conf['reverse_proxy_header'] = 'HTTP_X_FORWARDED_FOR';
+
+{% endif %}


### PR DESCRIPTION
Let users role set secure path via var.  Set default for it here. Includes logan's work for alternate drush install method.

Depends on:
https://github.com/OULibraries/ansible-role-d7/pull/90

Motivation and Context
----------------------
We need to be able to specify the secure_path uniquely depending on what roles are being installed.  This functionality has been added to the users role, and now we're specifying a usable default var in this role.
Closes https://github.com/OULibraries/ansible-role-d7/issues/91

How Has This Been Tested?
-------------------------
vagrant up
d7_init.sh
