### PR TITLE
Fix content-encoding error

### DIFF
--- a/templates/d7_proxy.inc.j2
+++ b/templates/d7_proxy.inc.j2
@@ -1,8 +1,7 @@
-{% if d7_proxies is defined %}
 <?php
+{% if d7_proxies is defined %}
 ## Configure Drupal reverse proxy
 $conf['reverse_proxy'] = TRUE;
 $conf['reverse_proxy_addresses'] = array('{{ d7_proxies|join('\',\'') }}');
 $conf['reverse_proxy_header'] = 'HTTP_X_FORWARDED_FOR';
-
 {% endif %}


### PR DESCRIPTION
 Make sure d7_proxy.inc.php always starts with `<?php` so no white space can sneak in to the php output. 

Motivation and Context
----------------------
Whitespace in php output was causing content encoding error. 

How Has This Been Tested?
-------------------------
Updating role makes nonworking sites into working ones. 
