### PR TITLE
Handle slugs.with.dots when creating databases

### DIFF
--- a/files/d7_clean.sh
+++ b/files/d7_clean.sh
@@ -37,9 +37,10 @@ echo
 ## Get sudo password if needed because first sudo use is behind a pipe.
 sudo ls > /dev/null
 
-## Drop the database
-echo "Dropping database."
-echo "DROP DATABASE \`drupal_${SITE}_${ENV_NAME}\`" | sudo -u apache drush sql-cli -r "$SITEPATH/drupal"
+## Get the db name from drush and drop it.
+MYDB=$(drush -r "$SITEPATH/drupal" sql-connect | sed 's/.*\-\-database=//; s/ \-\-host=.*//')
+echo "Dropping database ${MYDB}."
+echo "DROP DATABASE \`${MYDB}\`" | sudo -u apache drush sql-cli -r "$SITEPATH/drupal"
 
 ## Change settings.php to 660
 sudo -u apache chmod ug=rw,o= "$SITEPATH/default/settings.php" 2>/dev/null || \

--- a/files/d7_init.sh
+++ b/files/d7_init.sh
@@ -66,7 +66,7 @@ echo "Linking default site into build."
 sudo -u apache ln -s "$SITEPATH/default" "$SITEPATH/drupal/sites/default" || exit 1;
 
 
-DBSLUG=$(echo  '${SITE}' | tr -c 'A-Za-z_0-9' '_')
+DBSLUG=$(echo  "${SITE}" | tr -c 'A-Za-z_0-9' '_')
 
 echo "Generating settings.php with database ${DBSLUG}."
 read -r -d '' SETTINGSPHP <<- EOF

--- a/files/d7_init.sh
+++ b/files/d7_init.sh
@@ -65,14 +65,17 @@ sudo -u apache mv "$SITEPATH/drupal/sites/default" "$SITEPATH"/
 echo "Linking default site into build."
 sudo -u apache ln -s "$SITEPATH/default" "$SITEPATH/drupal/sites/default" || exit 1;
 
-echo "Generating settings.php."
+
+DBSLUG=$(echo  '${SITE}' | tr -c 'A-Za-z_0-9' '_')
+
+echo "Generating settings.php with database ${DBSLUG}."
 read -r -d '' SETTINGSPHP <<- EOF
 \$databases = array (
   'default' =>
   array (
     'default' =>
     array (
-      'database' => 'drupal_${SITE}_${ENV_NAME}',
+      'database' => 'drupal_${DBSLUG}_${ENV_NAME}',
       'username' => '${MY_DBSU}',
       'password' => '${MY_DBSU_PASS}',
       'host' => '$MY_DBHOST',

--- a/files/d7_init.sh
+++ b/files/d7_init.sh
@@ -65,8 +65,8 @@ sudo -u apache mv "$SITEPATH/drupal/sites/default" "$SITEPATH"/
 echo "Linking default site into build."
 sudo -u apache ln -s "$SITEPATH/default" "$SITEPATH/drupal/sites/default" || exit 1;
 
-
-DBSLUG=$(echo  "${SITE}" | tr -c 'A-Za-z_0-9' '_')
+## Sanitize the DB slug by excluding everything that MySQL doesn't like
+DBSLUG=$(echo -n  "${SITE}" | tr -C '_A-Za-z0-9' '_')
 
 echo "Generating settings.php with database ${DBSLUG}."
 read -r -d '' SETTINGSPHP <<- EOF


### PR DESCRIPTION
Replace characters that MySQL doesn't like in DB names with "_". 

Motivation and Context
----------------------
Closes #92. Our current `drush` errors out on names that it doesn't think MySQL will like.

How Has This Been Tested?
-------------------------
Tested creation and deletion of sites with slugs.with.dots. 
Used in dev for a couple of weeks with no issues. 