### PR TITLE
Add permissions fix to nightly cron

### DIFF
--- a/files/d7_daily.cron
+++ b/files/d7_daily.cron
@@ -2,11 +2,12 @@
 printf "Searching for Drupal sites.\n"
 find -L /srv -maxdepth 1 -mindepth 1 -type d 2>/dev/null | while read -r SITEPATH ; do
   # Check for settings.php
-  stat ${SITEPATH}/default/settings.php &>/dev/null
+  stat "${SITEPATH}/default/settings.php" &>/dev/null
   if [ "$?" -eq "0" ]; then
-    printf "Backing up ${SITEPATH}\n"
-    /opt/d7/bin/d7_snapshot.sh ${SITEPATH}
-    /opt/d7/bin/d7_update.sh ${SITEPATH}
+    printf "Backing up %s\n" "${SITEPATH}"
+    /opt/d7/bin/d7_snapshot.sh "${SITEPATH}"
+    /opt/d7/bin/d7_update.sh "${SITEPATH}"
+    /opt/d7/bin/d7_perms_fix.sh "${SITEPATH}"
   fi
 done
 


### PR DESCRIPTION
* Add permissions fix to nightly cron
* Assorted shellcheck motivated refactors

Motivation and Context
----------------------
New files installed by update might not have correct permissions and/or SELinux context. Maybe we should be applying permissions nightly as well? 

How Has This Been Tested?
-------------------------
Testing in progress. 
