### PR TITLE
Add drush.ini and set memory_limit with var in php.ini.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,3 +39,6 @@ apc_enabled: "1"
 ## test and prod at aws
 # d7_proxies:
 #  - 127.0.0.1
+
+# Memory needed for Drupal sites
+d7_memory_limit: "128M"

--- a/files/drush.ini
+++ b/files/drush.ini
@@ -1,0 +1,79 @@
+;
+; Example of a drush php settings override file
+;
+; IMPORTANT:  Before following the instructions in
+; this file, first check to see that the cli version
+; of php is installed on your system.  (e.g. On
+; debian systems, `sudo apt-get install php5-cli`.)
+;
+; Use this file in instances when your system is
+; -not- configured to use separate php.ini files for
+; webserver and cli use.  You can determine which
+; php.ini file drush is using by running "drush status".
+; If the php.ini file shown is your webserver ini
+; file, then rename this file, example.drush.ini,
+; to drush.ini and copy it to one of the following
+; locations:
+;
+; 1. Drush installation folder
+; 2. User's .drush folder (i.e. ~/.drush/drush.ini)
+; 3. System wide configuration folder (i.e. /etc/drush/drush.ini)
+;
+; If the environment variable DRUSH_INI is defined,
+; then the file it specified will be used as drush.ini.
+;
+;    export DRUSH_INI='/path/to/drush.ini'
+;
+; When in use, the variables defined in this file
+; will override the setting values that appear in
+; your php.ini file.  See the examples below for
+; some values that may need to be set in order for
+; drush to work.
+;
+; NOTE:  There is a certain amount of overhead
+; required for each override, so drush.ini should
+; only be used for a relatively small number
+; of variables.  Comment out any variable that
+; has the same value as the webserver php.ini
+; to keep the size of the override list small.
+;
+; To fully specify the value of all php.ini variables,
+; copy your webserver php.ini file to one of the
+; locations mentioned above (e.g. /etc/drush/php.ini)
+; and edit it to suit.  Alternately, you may use
+; the environment variable PHP_INI to point at
+; the file that Drush should use.
+;
+;    export PHP_INI='/path/to/php.ini'
+;
+; The options listed below are particularly relevant
+; to drush.
+;
+
+;
+; drush needs as much memory as Drupal in order
+; to run; make the memory limit setting match
+; what you have in your webserver's php.ini.
+;
+memory_limit = 300M
+
+;
+; Show all errors and direct them to stderr
+; when running drush.
+;
+error_reporting = E_ALL | E_NOTICE | E_STRICT
+display_errors = stderr
+
+;
+; If your php.ini for your webserver is too
+; restrictive, you can re-enable functionality
+; for drush by adjusting values in this file.
+;
+; Here are some examples of settings that are
+; sometimes set to restrictive values in a
+; webserver's php.ini:
+;
+;safe_mode =
+;open_basedir =
+;disable_functions =
+;disable_classes =

--- a/tasks/assets.yml
+++ b/tasks/assets.yml
@@ -105,4 +105,19 @@
     group: wheel
     mode: 0444
 
-    
+- name: Ensure /etc/drush exists
+  file:
+    path: /etc/drush
+    state: directory
+    mode: 0655
+    owner: root
+    group: wheel
+    recurse: yes
+
+- name: Install drush.ini
+  copy:
+    src: drush.ini
+    dest: /etc/drush
+    mode: 0644
+    owner: root
+    group: wheel

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -11,7 +11,7 @@
     owner: root
     group: apache
     mode: 0750
-- name: Add config include to http.conf
+- name: Add /srv config include to http.conf
   lineinfile:
     state: present
     dest: /etc/httpd/conf/httpd.conf
@@ -29,6 +29,13 @@
       ^post_max_size = 8M$
     replace: "post_max_size = 70M"
 
+- name: Set php.ini memory_limit
+  replace:
+    dest: /etc/php.ini
+    regexp: >
+      ^memory_limit = .*$
+    replace: "memory_limit = {{ d7_memory_limit }}"
+    
 - name: Set PHP timezone
   replace:
     dest: /etc/php.ini


### PR DESCRIPTION
Add `/etc/drush/drush.ini` for drush-specific php settings (recommended in drush docs). 
Set php `memory_limit` based on `d7_memory_limit` Ansible variable

Motivation and Context
----------------------
We need to control the amount of memory allowed for both our Drupal sites and Drush scripts and setting these separately will let us use the least amount for each. 

Status/Testing
-------------------------
Proposed change, lightly tested. 