### PR TITLE
Make update conditional and fix perms before clearing cache.

### DIFF
--- a/files/d7_importdb.sh
+++ b/files/d7_importdb.sh
@@ -5,10 +5,10 @@ source /opt/d7/etc/d7_conf.sh
 
 if [  -z "$1" ]; then
   cat <<USAGE
-d7_importdb.sh imports a Drupal database file. 
+d7_importdb.sh imports a Drupal database file.
 
 Usage: d7_importdb.sh.sh \$SITEPATH [\$DBFILE]
-            
+
 \$SITEPATH  Drupal site path
 \$DBFILE    Drupal database file to load
 
@@ -34,7 +34,7 @@ then
     DBFILE=$2
 else
     DBFILE="${SITEPATH}/db/drupal_${SITE}_dump.sql"
-fi       
+fi
 
 if [[ ! -f $DBFILE ]]; then
     echo "No file exists at ${DBFILE}."
@@ -47,7 +47,7 @@ then
 else
     echo "Target DB doesn't exist, we need to create it. "
 
-    # Get mysql host 
+    # Get mysql host
     read -r -e -p "Enter MYSQL host name: " -i "$D7_DBHOST" MY_DBHOST
     # Get mysql port
     read -r -e -p "Enter MYSQL host port: " -i "$D7_DBPORT" MY_DBPORT
@@ -57,9 +57,9 @@ else
     # Get DB admin password
     read -r -s -p "Enter MYSQL root password: " MY_DBSU_PASS
     while  [ -z "$MY_DBSU_PASS" ] || ! mysql --host="$MY_DBHOST" --port="$MY_DBPORT" --user="$MY_DBSU" --password="$MY_DBSU_PASS"  -e ";" ; do
-        read -r -s -p "Can't connect, please retry: " MY_DBSU_PASS
+	read -r -s -p "Can't connect, please retry: " MY_DBSU_PASS
     done
-    
+
     ## Create the Drupal database
     sudo -u apache drush -y sql-create --db-url="mysql://${MY_DBSU}:${MY_DBSU_PASS}@${MY_DBHOST}:${MY_DBPORT}/drupal_${SITE}_${ENV_NAME}" -r "$SITEPATH/drupal" || exit 1;
 fi
@@ -69,6 +69,6 @@ echo "Importing database for $SITE from file at $DBFILE."
 sudo -u apache drush sql-cli -r "$SITEPATH/drupal" < "${DBFILE}" || exit 1;
 echo "Database imported."
 
-
-## Apply security updates and clear caches.
+## Restored DBs might need module security updates
+## This will also clear all caches
 d7_update.sh "$SITEPATH" || exit 1;

--- a/files/d7_sync.sh
+++ b/files/d7_sync.sh
@@ -10,12 +10,12 @@ d7_synch.sh syncs content files and database from a remote site to a
 local Drupal site, creating it if it doesn't exist.
 
 Usage: d7_sync.sh \$SITEPATH \$SRCHOST [\$ORIGIN_SITEPATH]
-    
+
 \$SITEPATH         local target of the sync
-\$SRCHOST          host from which to sync  
-\$ORIGIN_SITEPATH  optional argument, path to sync on the remote host. 
-                   \$SITEPATH will be used if a different $ORIGIN_SITEPATH 
-                   is not specified. 
+\$SRCHOST          host from which to sync
+\$ORIGIN_SITEPATH  optional argument, path to sync on the remote host.
+		   \$SITEPATH will be used if a different $ORIGIN_SITEPATH
+		   is not specified.
 USAGE
 
   exit 1;
@@ -24,7 +24,7 @@ fi
 SITEPATH=$1
 SRCHOST=$2
 if [ ! -z "$3" ]; then
-    ORIGIN_SITEPATH=$3 
+    ORIGIN_SITEPATH=$3
 else
     ORIGIN_SITEPATH=$SITEPATH
 fi
@@ -40,22 +40,22 @@ if [[ ! -e $SITEPATH ]]; then
     d7_init.sh "$SITEPATH" || exit 1;
 fi
 
-
 ## Drupal default site dir is ~ 6770
 d7_perms.sh --sticky "$SITEPATH/default"
 
 ## Make the sync directory
+echo "Prepare sync destination."
 sudo -u apache mkdir -p "$SITEPATH/default/files_sync"
-echo "Setting permissions for synced files."
 d7_perms.sh --sticky "$SITEPATH/default/files_sync"
 
 ## Sync Files to writable directory (sudo would break ssh)
+echo "Begin syncing."
 RSOPTS="--verbose --recursive --links  --compress"
-rsync  $RSOPTS  "$SRCHOST:$ORIGIN_SITEPATH/default/files/" "$SITEPATH/default/files_sync" | while read $RSFILE; do printf "."; done; 
+rsync  $RSOPTS  "$SRCHOST:$ORIGIN_SITEPATH/default/files/" "$SITEPATH/default/files_sync" | while read $RSFILE; do printf "."; done;
 echo "Files synced."
 
 ## Set perms for sync directory
-echo "Setting permissions for synced files."
+echo "Set permissions for synced files."
 d7_perms.sh --sticky "$SITEPATH/default/files_sync"
 
 ## Now that everything is ready, swap in the synced files

--- a/files/d7_update.sh
+++ b/files/d7_update.sh
@@ -21,14 +21,14 @@ echo "Processing $SITEPATH"
 
 
 # Check for available updates
-UPDATELIST="$(drush pm-updatestatus --security-only --pipe)"
+UPDATELIST=$(drush -r "${SITEPATH}/drupal" pm-updatestatus --security-only --pipe)
 if [ "" == "${UPDATELIST}" ] ; then
     echo "No security updates available"
-    exit 1
+    exit 0
 fi
 
 
-## Dump DB before touching anything
+## dump DB before touching anything
 d7_dump.sh "$SITEPATH" || exit 1;
 
 ## Enable update manager.
@@ -41,7 +41,7 @@ sudo -u apache drush up -y --security-only -r "$SITEPATH/drupal"  --no-backup  |
 sudo -u apache drush -y dis update -r "$SITEPATH/drupal" || exit 1;
 
 ## Make sure any updated php is readable
-d7_perms_fix.sh "$SITEPATH"
+d7_perms.sh "$SITEPATH/drupal"
 
 ## Make sure new code is loaded
 d7_cc.sh "$SITEPATH"

--- a/files/d7_update.sh
+++ b/files/d7_update.sh
@@ -8,7 +8,7 @@ if [  -z "$1" ]; then
 d7_update.sh applies security (only) updates to a drupal site.
 
 Usage: d7_update.sh \$SITEPATH
-            
+
 \$SITEPATH   Drupal site to update.
 USAGE
 
@@ -18,6 +18,15 @@ fi
 SITEPATH=$1
 
 echo "Processing $SITEPATH"
+
+
+# Check for available updates
+UPDATELIST="$(drush pm-updatestatus --security-only --pipe)"
+if [ "" == "${UPDATELIST}" ] ; then
+    echo "No security updates available"
+    exit 1
+fi
+
 
 ## Dump DB before touching anything
 d7_dump.sh "$SITEPATH" || exit 1;
@@ -31,12 +40,11 @@ sudo -u apache drush up -y --security-only -r "$SITEPATH/drupal"  --no-backup  |
 ## Disable update manager; no need to leave it phoning home.
 sudo -u apache drush -y dis update -r "$SITEPATH/drupal" || exit 1;
 
-## Clear the caches
+## Make sure any updated php is readable
+d7_perms_fix.sh "$SITEPATH"
+
+## Make sure new code is loaded
 d7_cc.sh "$SITEPATH"
 
 ## Avoid a known performance-crusher in our environment
 sudo -u apache drush eval 'variable_set('drupal_http_request_fails', 0)' -r "$SITEPATH/drupal" || exit 1;
-
-## settings.php is protected.
-sudo -u apache chmod ug=r,o= "$SITEPATH/default/settings.php" 2>/dev/null || \
-chmod ug=r,o= "$SITEPATH/default/settings.php"


### PR DESCRIPTION
* Make update process conditional on the presence of updates
* Fix permissions for drupal code when doing update 
* Clean up white space
* Clarify output and comments
* Replace `d7_update.sh` in `d7_init.sh` with `d7_cc.sh` 

Motivation and Context
----------------------
* Set correct permissions for updated modules to close #95
* General cleanup of related text UI 
* Don't check for updates immediately after core install, none will be available. 

Testing
-------------------------
- [x] No updates or permissions work when no modules are out of date.
- [x] Successful update of outdated Drupal core
- [x] Successful migration of site with out-of-date makefile and updated modules. 

