### PR TITLE
Harvest default/files and default/files/private config from .htaccess

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,14 +40,13 @@ apc_enabled: "1"
 # d7_proxies:
 #  - 127.0.0.1
 
-# Memory needed for Drupal sites
+# Drupal related settings
 d7_memory_limit: "128M"
-
 d7_max_filesize: "64M"
 d7_post_max_size: "70M"
-
 d7_date_timezone: "America/Chicago"
 
+# Control of PHP session expiration
 d7_session_cookie_lifetime: "2000000"
 d7_session_gc_probability: "1"
 d7_session_gc_divisor: "100"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -42,6 +42,12 @@ apc_enabled: "1"
 
 # Memory needed for Drupal sites
 d7_memory_limit: "128M"
+
 d7_max_filesize: "64M"
 d7_post_max_size: "70M"
+
 d7_date_timezone: "America/Chicago"
+
+d7_session_cookie_lifetime = "2000000"
+d7_session_gc_probability = "1"
+d7_session_gc_divisor = "100"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -48,6 +48,6 @@ d7_post_max_size: "70M"
 
 d7_date_timezone: "America/Chicago"
 
-d7_session_cookie_lifetime = "2000000"
-d7_session_gc_probability = "1"
-d7_session_gc_divisor = "100"
+d7_session_cookie_lifetime: "2000000"
+d7_session_gc_probability: "1"
+d7_session_gc_divisor: "100"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -42,3 +42,6 @@ apc_enabled: "1"
 
 # Memory needed for Drupal sites
 d7_memory_limit: "128M"
+d7_max_filesize: "64M"
+d7_post_max_size: "70M"
+d7_date_timezone: "America/Chicago"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -42,7 +42,7 @@ apc_enabled: "1"
 
 # Drupal related settings
 d7_memory_limit: "128M"
-d7_max_filesize: "64M"
+d7_upload_max_filesize: "64M"
 d7_post_max_size: "70M"
 d7_date_timezone: "America/Chicago"
 

--- a/files/d7_httpd_conf.sh
+++ b/files/d7_httpd_conf.sh
@@ -8,12 +8,12 @@ if [  -z "$1" ]; then
 
   cat <<USAGE
 
-d7_httpd_conf.sh generates the Apache config for a site.
+d7_httpd_conf.sh generates or updates the Apache config for a site.
 
 Usage: d7_httpd_conf.sh \$SITEPATH [\$SITETYPE]
 
-\$SITEPATH  Drupal site.
-\$SITETYPE  Should be "master" or "sub". Default is master. 
+\$SITEPATH  local path for Drupal site (eg. /srv/example).
+\$SITETYPE  (optional) site type: "master" or "sub". Default is master.
 
 USAGE
 
@@ -36,13 +36,10 @@ if [ ! -z "$2" ]; then
 	  echo "Bad site type: $2"
 	  exit 1
     fi
-
-    SITETYPE="$2"    
+    SITETYPE="$2"
 fi
 
-
 echo "Appling configuration type $SITETYPE at $SITEPATH"
-
 
 ## Grab the basename of the site to use in conf.
 SITE=$(basename "$SITEPATH")
@@ -88,7 +85,7 @@ ${SRV_SITE_CONF}
     Allow from all
     Require all granted
     AllowOverride None
-     
+
     RewriteEngine on
     RewriteBase /${SUBSITE}
     Include /etc/httpd/conf.d/drupal.include

--- a/files/d7_httpd_conf.sh
+++ b/files/d7_httpd_conf.sh
@@ -10,10 +10,10 @@ if [  -z "$1" ]; then
 
 d7_httpd_conf.sh generates the Apache config for a site.
 
-Usage: d7_httpd_conf.sh \$SITEPATH [\$SITE_TYPE]
+Usage: d7_httpd_conf.sh \$SITEPATH [\$MASTERPATH]
 
 \$SITEPATH  Drupal site.
-\$SITE_TYPE  optional argument, standalone (default), master, or sub.
+\$MASTERPATH  Optional master site for subsite
 
 USAGE
 
@@ -30,11 +30,10 @@ if [[ ! -e $SITEPATH ]]; then
 fi
 
 if [ ! -z "$2" ]; then
-  if [ "$2" == "standalone" ] || [ "$2" == "master" ] || [ "$2" == "sub" ]; then
-    SITE_TYPE=$2
-  fi
+    SITE_TYPE="sub"
+    MASTERPATH="$2"
 else
-    SITE_TYPE=standalone
+    SITE_TYPE=master
 fi
 
 ## Grab the basename of the site to use in conf.
@@ -44,14 +43,7 @@ SITE=$(basename "$SITEPATH")
 echo "Generating Apache config for ${SITEPATH}."
 sudo -u apache mkdir -p "$SITEPATH/etc"
 
-## Standalone config gets our original template
-if [ "$SITE_TYPE" == "standalone" ]; then
-  sudo -u apache sh -c "sed "s/__SITE_DIR__/$SITE/g" /opt/d7/etc/d7_init_httpd_template > $SITEPATH/etc/srv_$SITE.conf" || exit 1;
-  sudo -u apache sh -c "sed -i "s/__SITE_NAME__/$SITE/g" $SITEPATH/etc/srv_$SITE.conf" || exit 1;
-
-# Master gets a special interactive configuration
-
-elif [ "$SITE_TYPE" == "master" ]; then
+if [ "$SITE_TYPE" == "master" ]; then
   echo "Generating ${SITEPATH}/etc/srv_${SITE}.conf with additional subsite information."
 
   # Start off normally
@@ -71,163 +63,14 @@ elif [ "$SITE_TYPE" == "master" ]; then
     Allow from all
     Require all granted
     AllowOverride None
-    #
-    # Apache/PHP/Drupal settings:
-    #
-
-    # Protect files and directories from prying eyes.
-    <FilesMatch "\.(engine|inc|info|install|make|module|profile|test|po|sh|.*sql|theme|tpl(\.php)?|xtmpl)(~|\.sw[op]|\.bak|\.orig|\.save)?$|^(\..*|Entries.*|Repository|Root|Tag|Template|composer\.(json|lock))$|^#.*#$|\.php(~|\.sw[op]|\.bak|\.orig\.save)$">
-      Order allow,deny
-    </FilesMatch>
-
-    # Don't show directory listings for URLs which map to a directory.
-    Options -Indexes
-
-    # Follow symbolic links in this directory.
-    Options +FollowSymLinks
-
-    # Make Drupal handle any 404 errors.
-    ErrorDocument 404 /index.php
-
-    # Set the default handler.
-    DirectoryIndex index.php index.html index.htm
-
-    # Override PHP settings that cannot be changed at runtime. See
-    # sites/default/default.settings.php and drupal_environment_initialize() in
-    # includes/bootstrap.inc for settings that can be changed at runtime.
-
-    # PHP 5, Apache 1 and 2.
-    <IfModule mod_php5.c>
-      php_flag magic_quotes_gpc                 off
-      php_flag magic_quotes_sybase              off
-      php_flag register_globals                 off
-      php_flag session.auto_start               off
-      php_value mbstring.http_input             pass
-      php_value mbstring.http_output            pass
-      php_flag mbstring.encoding_translation    off
-    </IfModule>
-
-    # Requires mod_expires to be enabled.
-    <IfModule mod_expires.c>
-      # Enable expirations.
-      ExpiresActive On
-
-      # Cache all files for 2 weeks after access (A).
-      ExpiresDefault A1209600
-
-      <FilesMatch \.php$>
-        # Do not allow PHP scripts to be cached unless they explicitly send cache
-        # headers themselves. Otherwise all scripts would have to overwrite the
-        # headers set by mod_expires if they want another caching behavior. This may
-        # fail if an error occurs early in the bootstrap process, and it may cause
-        # problems if a non-Drupal PHP file is installed in a subdirectory.
-        ExpiresActive Off
-      </FilesMatch>
-    </IfModule>
-
-    # Various rewrite rules.
-    <IfModule mod_rewrite.c>
-      RewriteEngine on
-
-      # Set "protossl" to "s" if we were accessed via https://.  This is used later
-      # if you enable "www." stripping or enforcement, in order to ensure that
-      # you don't bounce between http and https.
-      RewriteRule ^ - [E=protossl]
-      RewriteCond %{HTTPS} on
-      RewriteRule ^ - [E=protossl:s]
-
-      # Make sure Authorization HTTP header is available to PHP
-      # even when running as CGI or FastCGI.
-      RewriteRule ^ - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
-
-      # Block access to "hidden" directories whose names begin with a period. This
-      # includes directories used by version control systems such as Subversion or
-      # Git to store control files. Files whose names begin with a period, as well
-      # as the control files used by CVS, are protected by the FilesMatch directive
-      # above.
-      #
-      # NOTE: This only works when mod_rewrite is loaded. Without mod_rewrite, it is
-      # not possible to block access to entire directories from .htaccess, because
-      # <DirectoryMatch> is not allowed here.
-      #
-      # If you do not have mod_rewrite installed, you should remove these
-      # directories from your webroot or otherwise protect them from being
-      # downloaded.
-      RewriteRule "(^|/)\." - [F]
-
-      # If your site can be accessed both with and without the 'www.' prefix, you
-      # can use one of the following settings to redirect users to your preferred
-      # URL, either WITH or WITHOUT the 'www.' prefix. Choose ONLY one option:
-      #
-      # To redirect all users to access the site WITH the 'www.' prefix,
-      # (http://example.com/... will be redirected to http://www.example.com/...)
-      # uncomment the following:
-      # RewriteCond %{HTTP_HOST} .
-      # RewriteCond %{HTTP_HOST} !^www\. [NC]
-      # RewriteRule ^ http%{ENV:protossl}://www.%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
-      #
-      # To redirect all users to access the site WITHOUT the 'www.' prefix,
-      # (http://www.example.com/... will be redirected to http://example.com/...)
-      # uncomment the following:
-      # RewriteCond %{HTTP_HOST} ^www\.(.+)$ [NC]
-      # RewriteRule ^ http%{ENV:protossl}://%1%{REQUEST_URI} [L,R=301]
-
-      # Modify the RewriteBase if you are using Drupal in a subdirectory or in a
-      # VirtualDocumentRoot and the rewrite rules are not working properly.
-      # For example if your site is at http://example.com/drupal uncomment and
-      # modify the following line:
-      # RewriteBase /drupal
-      #
-      # If your site is running in a VirtualDocumentRoot at http://example.com/,
-      # uncomment the following line:
-      # RewriteBase /
-
-      # Pass all requests not referring directly to files in the filesystem to
-      # index.php. Clean URLs are handled in drupal_environment_initialize().
-      RewriteCond %{REQUEST_FILENAME} !-f
-      RewriteCond %{REQUEST_FILENAME} !-d
-      RewriteCond %{REQUEST_URI} !=/favicon.ico
-      RewriteRule ^ index.php [L]
-
-      # Rules to correctly serve gzip compressed CSS and JS files.
-      # Requires both mod_rewrite and mod_headers to be enabled.
-      <IfModule mod_headers.c>
-        # Serve gzip compressed CSS files if they exist and the client accepts gzip.
-        RewriteCond %{HTTP:Accept-encoding} gzip
-        RewriteCond %{REQUEST_FILENAME}\.gz -s
-        RewriteRule ^(.*)\.css $1\.css\.gz [QSA]
-
-        # Serve gzip compressed JS files if they exist and the client accepts gzip.
-        RewriteCond %{HTTP:Accept-encoding} gzip
-        RewriteCond %{REQUEST_FILENAME}\.gz -s
-        RewriteRule ^(.*)\.js $1\.js\.gz [QSA]
-
-        # Serve correct content types, and prevent mod_deflate double gzip.
-        RewriteRule \.css\.gz$ - [T=text/css,E=no-gzip:1]
-        RewriteRule \.js\.gz$ - [T=text/javascript,E=no-gzip:1]
-
-        <FilesMatch "(\.js\.gz|\.css\.gz)$">
-          # Serve correct encoding type.
-          Header set Content-Encoding gzip
-          # Force proxies to cache gzipped & non-gzipped css/js files separately.
-          Header append Vary Accept-Encoding
-        </FilesMatch>
-      </IfModule>
-    </IfModule>
-
-    # Add headers to all responses.
-    <IfModule mod_headers.c>
-      # Disable content sniffing, since it's an attack vector.
-      Header always set X-Content-Type-Options nosniff
-    </IfModule>
+    Include /etc/httpd/conf.d/drupal.include
   </Directory>
 EOF
-  ## Ask for a list of sub sites and do some config for each of them
-  # list of subsites
-  read -r -e -p "Enter comma-separated list of subsite paths: " SUBSITEPATHS
-  for SUBSITEPATH in $( echo ${SUBSITEPATHS} | tr "," "\n" ); do
-    SUBSITE=$(basename "$SUBSITEPATH")
-    read -r -d '' SRV_SITE_CONF <<- EOF
+
+  for SUBSITEPATH in $( cat "${SITEPATH}/etc/subsites" ); do
+      SUBSITE=$(basename "$SUBSITEPATH")
+      read -r -d '' SRV_SITE_CONF <<- EOF
+
 ${SRV_SITE_CONF}
 
   Alias /${SUBSITE} /srv/${SUBSITE}/drupal
@@ -237,158 +80,11 @@ ${SRV_SITE_CONF}
     Allow from all
     Require all granted
     AllowOverride None
-    #
-    # Apache/PHP/Drupal settings:
-    #
-
-    # Protect files and directories from prying eyes.
-    <FilesMatch "\.(engine|inc|info|install|make|module|profile|test|po|sh|.*sql|theme|tpl(\.php)?|xtmpl)(~|\.sw[op]|\.bak|\.orig|\.save)?$|^(\..*|Entries.*|Repository|Root|Tag|Template|composer\.(json|lock))$|^#.*#$|\.php(~|\.sw[op]|\.bak|\.orig\.save)$">
-      Order allow,deny
-    </FilesMatch>
-
-    # Don't show directory listings for URLs which map to a directory.
-    Options -Indexes
-
-    # Follow symbolic links in this directory.
-    Options +FollowSymLinks
-
-    # Make Drupal handle any 404 errors.
-    ErrorDocument 404 /index.php
-
-    # Set the default handler.
-    DirectoryIndex index.php index.html index.htm
-
-    # Override PHP settings that cannot be changed at runtime. See
-    # sites/default/default.settings.php and drupal_environment_initialize() in
-    # includes/bootstrap.inc for settings that can be changed at runtime.
-
-    # PHP 5, Apache 1 and 2.
-    <IfModule mod_php5.c>
-      php_flag magic_quotes_gpc                 off
-      php_flag magic_quotes_sybase              off
-      php_flag register_globals                 off
-      php_flag session.auto_start               off
-      php_value mbstring.http_input             pass
-      php_value mbstring.http_output            pass
-      php_flag mbstring.encoding_translation    off
-    </IfModule>
-
-    # Requires mod_expires to be enabled.
-    <IfModule mod_expires.c>
-      # Enable expirations.
-      ExpiresActive On
-
-      # Cache all files for 2 weeks after access (A).
-      ExpiresDefault A1209600
-
-      <FilesMatch \.php$>
-        # Do not allow PHP scripts to be cached unless they explicitly send cache
-        # headers themselves. Otherwise all scripts would have to overwrite the
-        # headers set by mod_expires if they want another caching behavior. This may
-        # fail if an error occurs early in the bootstrap process, and it may cause
-        # problems if a non-Drupal PHP file is installed in a subdirectory.
-        ExpiresActive Off
-      </FilesMatch>
-    </IfModule>
-
-    # Various rewrite rules.
-    <IfModule mod_rewrite.c>
-      RewriteEngine on
-
-      # Set "protossl" to "s" if we were accessed via https://.  This is used later
-      # if you enable "www." stripping or enforcement, in order to ensure that
-      # you don't bounce between http and https.
-      RewriteRule ^ - [E=protossl]
-      RewriteCond %{HTTPS} on
-      RewriteRule ^ - [E=protossl:s]
-
-      # Make sure Authorization HTTP header is available to PHP
-      # even when running as CGI or FastCGI.
-      RewriteRule ^ - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
-
-      # Block access to "hidden" directories whose names begin with a period. This
-      # includes directories used by version control systems such as Subversion or
-      # Git to store control files. Files whose names begin with a period, as well
-      # as the control files used by CVS, are protected by the FilesMatch directive
-      # above.
-      #
-      # NOTE: This only works when mod_rewrite is loaded. Without mod_rewrite, it is
-      # not possible to block access to entire directories from .htaccess, because
-      # <DirectoryMatch> is not allowed here.
-      #
-      # If you do not have mod_rewrite installed, you should remove these
-      # directories from your webroot or otherwise protect them from being
-      # downloaded.
-      RewriteRule "(^|/)\." - [F]
-
-      # If your site can be accessed both with and without the 'www.' prefix, you
-      # can use one of the following settings to redirect users to your preferred
-      # URL, either WITH or WITHOUT the 'www.' prefix. Choose ONLY one option:
-      #
-      # To redirect all users to access the site WITH the 'www.' prefix,
-      # (http://example.com/... will be redirected to http://www.example.com/...)
-      # uncomment the following:
-      # RewriteCond %{HTTP_HOST} .
-      # RewriteCond %{HTTP_HOST} !^www\. [NC]
-      # RewriteRule ^ http%{ENV:protossl}://www.%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
-      #
-      # To redirect all users to access the site WITHOUT the 'www.' prefix,
-      # (http://www.example.com/... will be redirected to http://example.com/...)
-      # uncomment the following:
-      # RewriteCond %{HTTP_HOST} ^www\.(.+)$ [NC]
-      # RewriteRule ^ http%{ENV:protossl}://%1%{REQUEST_URI} [L,R=301]
-
-      # Modify the RewriteBase if you are using Drupal in a subdirectory or in a
-      # VirtualDocumentRoot and the rewrite rules are not working properly.
-      # For example if your site is at http://example.com/drupal uncomment and
-      # modify the following line:
-      RewriteBase /${SUBSITE}
-      #
-      # If your site is running in a VirtualDocumentRoot at http://example.com/,
-      # uncomment the following line:
-      # RewriteBase /
-
-      # Pass all requests not referring directly to files in the filesystem to
-      # index.php. Clean URLs are handled in drupal_environment_initialize().
-      RewriteCond %{REQUEST_FILENAME} !-f
-      RewriteCond %{REQUEST_FILENAME} !-d
-      RewriteCond %{REQUEST_URI} !=/favicon.ico
-      RewriteRule ^ index.php [L]
-
-      # Rules to correctly serve gzip compressed CSS and JS files.
-      # Requires both mod_rewrite and mod_headers to be enabled.
-      <IfModule mod_headers.c>
-        # Serve gzip compressed CSS files if they exist and the client accepts gzip.
-        RewriteCond %{HTTP:Accept-encoding} gzip
-        RewriteCond %{REQUEST_FILENAME}\.gz -s
-        RewriteRule ^(.*)\.css $1\.css\.gz [QSA]
-
-        # Serve gzip compressed JS files if they exist and the client accepts gzip.
-        RewriteCond %{HTTP:Accept-encoding} gzip
-        RewriteCond %{REQUEST_FILENAME}\.gz -s
-        RewriteRule ^(.*)\.js $1\.js\.gz [QSA]
-
-        # Serve correct content types, and prevent mod_deflate double gzip.
-        RewriteRule \.css\.gz$ - [T=text/css,E=no-gzip:1]
-        RewriteRule \.js\.gz$ - [T=text/javascript,E=no-gzip:1]
-
-        <FilesMatch "(\.js\.gz|\.css\.gz)$">
-          # Serve correct encoding type.
-          Header set Content-Encoding gzip
-          # Force proxies to cache gzipped & non-gzipped css/js files separately.
-          Header append Vary Accept-Encoding
-        </FilesMatch>
-      </IfModule>
-    </IfModule>
-
-    # Add headers to all responses.
-    <IfModule mod_headers.c>
-      # Disable content sniffing, since it's an attack vector.
-      Header always set X-Content-Type-Options nosniff
-    </IfModule>
+    Include /etc/httpd/conf.d/drupal.include
   </Directory>
 EOF
   done
+
   ## Finish normally
   read -r -d '' SRV_SITE_CONF <<- EOF
 ${SRV_SITE_CONF}
@@ -396,7 +92,7 @@ ${SRV_SITE_CONF}
 </VirtualHost>
 EOF
 
-  sudo -u apache echo "$SRV_SITE_CONF"| sudo -u apache tee -a "$SITEPATH/etc/srv_$SITE.conf" >/dev/null
+sudo -u apache echo "$SRV_SITE_CONF"| sudo -u apache tee -a "$SITEPATH/etc/srv_$SITE.conf" >/dev/null
 
 # Subsite gets an empty configuration
 elif [ "$SITE_TYPE" == "sub" ]; then

--- a/files/d7_httpd_conf.sh
+++ b/files/d7_httpd_conf.sh
@@ -13,7 +13,7 @@ d7_httpd_conf.sh generates the Apache config for a site.
 Usage: d7_httpd_conf.sh \$SITEPATH [\$SITETYPE]
 
 \$SITEPATH  Drupal site.
-\$SITETYPE  Should be "master" or "sub"
+\$SITETYPE  Should be "master" or "sub". Default is master. 
 
 USAGE
 
@@ -31,7 +31,13 @@ if [[ ! -e $SITEPATH ]]; then
 fi
 
 if [ ! -z "$2" ]; then
-    SITETYPE="$2"
+
+    if [ ! "$2" == "master"  -o  "$2" == "sub"  ]; then
+	  echo "Bad site type:  $2"
+	  exit 1
+    fi
+
+    SITETYPE="$2"    
 fi
 
 

--- a/files/d7_httpd_conf.sh
+++ b/files/d7_httpd_conf.sh
@@ -32,8 +32,8 @@ fi
 
 if [ ! -z "$2" ]; then
 
-    if [ ! "$2" == "master"  -o  "$2" == "sub"  ]; then
-	  echo "Bad site type:  $2"
+    if [  "$2" != "master"  -a  "$2" != "sub"  ]; then
+	  echo "Bad site type: $2"
 	  exit 1
     fi
 

--- a/files/d7_httpd_conf.sh
+++ b/files/d7_httpd_conf.sh
@@ -90,6 +90,9 @@ ${SRV_SITE_CONF}
     RewriteBase /${SUBSITE}
     Include /etc/httpd/conf.d/drupal.include
   </Directory>
+
+  Include /etc/httpd/conf.d/drupal-files.include
+
 EOF
   done
 

--- a/files/d7_importdb.sh
+++ b/files/d7_importdb.sh
@@ -5,10 +5,10 @@ source /opt/d7/etc/d7_conf.sh
 
 if [  -z "$1" ]; then
   cat <<USAGE
-d7_importdb.sh imports a Drupal database file. 
+d7_importdb.sh imports a Drupal database file.
 
 Usage: d7_importdb.sh.sh \$SITEPATH [\$DBFILE]
-            
+
 \$SITEPATH  Drupal site path
 \$DBFILE    Drupal database file to load
 
@@ -34,7 +34,7 @@ then
     DBFILE=$2
 else
     DBFILE="${SITEPATH}/db/drupal_${SITE}_dump.sql"
-fi       
+fi
 
 if [[ ! -f $DBFILE ]]; then
     echo "No file exists at ${DBFILE}."
@@ -47,7 +47,7 @@ then
 else
     echo "Target DB doesn't exist, we need to create it. "
 
-    # Get mysql host 
+    # Get mysql host
     read -r -e -p "Enter MYSQL host name: " -i "$D7_DBHOST" MY_DBHOST
     # Get mysql port
     read -r -e -p "Enter MYSQL host port: " -i "$D7_DBPORT" MY_DBPORT
@@ -57,9 +57,9 @@ else
     # Get DB admin password
     read -r -s -p "Enter MYSQL root password: " MY_DBSU_PASS
     while  [ -z "$MY_DBSU_PASS" ] || ! mysql --host="$MY_DBHOST" --port="$MY_DBPORT" --user="$MY_DBSU" --password="$MY_DBSU_PASS"  -e ";" ; do
-        read -r -s -p "Can't connect, please retry: " MY_DBSU_PASS
+	read -r -s -p "Can't connect, please retry: " MY_DBSU_PASS
     done
-    
+
     ## Create the Drupal database
     sudo -u apache drush -y sql-create --db-url="mysql://${MY_DBSU}:${MY_DBSU_PASS}@${MY_DBHOST}:${MY_DBPORT}/drupal_${SITE}_${ENV_NAME}" -r "$SITEPATH/drupal" || exit 1;
 fi
@@ -69,6 +69,6 @@ echo "Importing database for $SITE from file at $DBFILE."
 sudo -u apache drush sql-cli -r "$SITEPATH/drupal" < "${DBFILE}" || exit 1;
 echo "Database imported."
 
-
-## Apply security updates and clear caches.
+## Restored DBs might need module security updates
+## This will also clear all caches
 d7_update.sh "$SITEPATH" || exit 1;

--- a/files/d7_init.sh
+++ b/files/d7_init.sh
@@ -17,14 +17,14 @@ USAGE
   exit 1;
 fi
 
-SITEPATH=$1
+SITEPATH="$(realpath  --canonicalize-missing --no-symlinks $1)"
 MASTERPATH=${SITEPATH}  # default to site being it's own master
 SITETYPE=master
 
 # some sites are subsites
 if [ ! -z "$2" ] && [ ! "${SITEPATH}" == "$2" ]; then
     SITETYPE="sub"
-    MASTERPATH="$2"
+    MASTERPATH="$(realpath  --canonicalize-missing --no-symlinks $2)"
 fi
 
 ## Don't blow away existing sites

--- a/files/d7_init.sh
+++ b/files/d7_init.sh
@@ -21,7 +21,7 @@ SITEPATH=$1
 MASTERPATH=${SITEPATH}
 SITETYPE=master
 
-if [ ! -z "$2" ]; then
+if [ ! -z "$2" ] && [ ! "${SITEPATH}" == "${MASTERPATH}" ]; then
     SITETYPE="sub"
     MASTERPATH="$2"
 fi

--- a/files/d7_init.sh
+++ b/files/d7_init.sh
@@ -9,8 +9,8 @@ d7_init.sh builds a Drupal site.
 
 Usage: d7_init.sh \$SITEPATH [\$MASTERPATH]
 
-\$SITEPATH  Destination for Drupal site (eg. /srv/example).
-\$MASTERPATH  Optional argument specifying a master site for this site.
+\$SITEPATH    local path for Drupal site (eg. /srv/example).
+\$MASTERPATH  (optional) local path to master site
 
 USAGE
 

--- a/files/d7_init.sh
+++ b/files/d7_init.sh
@@ -24,20 +24,19 @@ SITETYPE=master
 if [ ! -z "$2" ]; then
     SITETYPE="sub"
     MASTERPATH="$2"
-else
-
-
-## Grab the basename of the site to use in a few places.
-SITE=$(basename "$SITEPATH")
-
-## Sanitize the DB slug by excluding everything that MySQL doesn't like from $SITE
-DBSLUG=$(echo -n  "${SITE}" | tr -C '_A-Za-z0-9' '_')
+fi
 
 ## Don't blow away existing sites
 if [[ -e "$SITEPATH" ]]; then
     echo "$SITEPATH already exists!"
     exit 1
 fi
+
+## Grab the basename of the site to use in a few places
+SITE=$(basename "$SITEPATH")
+
+## Sanitize the DB slug by excluding everything that MySQL doesn't like from $SITE
+DBSLUG=$(echo -n  "${SITE}" | tr -C '_A-Za-z0-9' '_')
 
 echo "Initializing site at ${SITEPATH}."
 

--- a/files/d7_init.sh
+++ b/files/d7_init.sh
@@ -21,7 +21,7 @@ SITEPATH=$1
 MASTERPATH=${SITEPATH}
 SITETYPE=master
 
-if [ ! -z "$2" ] && [ ! "${SITEPATH}" == "${MASTERPATH}" ]; then
+if [ ! -z "$2" ] && [ ! "${SITEPATH}" == "$2" ]; then
     SITETYPE="sub"
     MASTERPATH="$2"
 fi
@@ -43,12 +43,13 @@ echo "Initializing site at ${SITEPATH}."
 # Get external host suffix (rev proxy, ngrok, etc)
 read -r -e -p "Enter host suffix: " -i "$D7_HOST_SUFFIX" MY_HOST_SUFFIX 
 
-SITE=$(basename "$MASTERPATH")
-
 # By default, we're operating at the root for a domain
 SUBPATH="";
+
+# Override for subsite
 if [ "$SITETYPE" == "sub" ]; then
     SUBPATH="/${SITE}"
+    SITE=$(basename "$MASTERPATH")
 fi
 
 ## Set some URL-related setings

--- a/files/d7_init.sh
+++ b/files/d7_init.sh
@@ -138,7 +138,7 @@ sudo -u apache drush -y sql-create --db-su="${MY_DBSU}" --db-su-pw="$MY_DBSU_PAS
 sudo -u apache drush -y -r "$SITEPATH/drupal" site-install --site-name="$SITE" || exit 1;
 
 ## Apply the apache config
-d7_httpd_conf.sh "$SITEPATH" "SITETYPE" || exit 1;
+d7_httpd_conf.sh "$SITEPATH" "$SITETYPE" || exit 1;
 
 ## Apply security updates and clear caches.
 d7_update.sh "$SITEPATH" || exit 1;

--- a/files/d7_migrate.sh
+++ b/files/d7_migrate.sh
@@ -8,12 +8,12 @@ if [ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ] ; then
     cat <<USAGE
 d7_migrate.sh migrates a site between hosts.
 
-Usage: d7_migrate.sh \$SITEPATH \$SRCHOST \$ORIGIN_SITEPATH [\$SITE_TYPE]
+Usage: d7_migrate.sh \$SITEPATH \$SRCHOST \$ORIGIN_SITEPATH [\$SITETYPE]
 
 \$SITEPATH          local Drupal path for new migrated site
 \$SRCHOST           host of site to migrate    
 \$ORIGIN_SITEPATH   path of site to migrate on \$SRCHOST  
-\$SITE_TYPE  optional argument, standalone (default), master, or sub. 
+\$SITETYPE  optional argument.  master (default), or sub. 
 USAGE
     exit 1;
 fi
@@ -23,11 +23,15 @@ SRCHOST=$2
 ORIGIN_SITEPATH=$3
 
 if [ ! -z "$4" ]; then
-  if [ "$4" == "standalone" ] || [ "$4" == "master" ] || [ "$4" == "sub" ]; then
-    SITE_TYPE=$4
-  fi
-else
-    SITE_TYPE=standalone
+
+
+    if [ ! "$4" == "master"  -o  "$4" == "sub"  ]; then
+	  echo "Bad site type:  $4"
+	  exit 1
+    fi
+
+    SITETYPE="$4"    
+
 fi
 
 if [  -e "$SITEPATH" ]; then
@@ -38,7 +42,7 @@ fi
 echo "Migrating site to ${SITEPATH} from ${SRCHOST} path ${ORIGIN_SITEPATH}."
 
 # Build an empty site 
-d7_init.sh "$SITEPATH" "$SITE_TYPE" || exit 1
+d7_init.sh "$SITEPATH" "$SITETYPE" || exit 1
 
 echo "Copying makefiles!"
 for file in "site.make" "site.make.uri" ; do

--- a/files/d7_migrate.sh
+++ b/files/d7_migrate.sh
@@ -19,7 +19,7 @@ USAGE
 fi
 
 SITEPATH=$1
-MASTERPATH=${SITEPATH}
+MASTERSITE=${SITEPATH}
 SITETYPE=master
 
 SRCHOST=$2
@@ -27,7 +27,7 @@ ORIGIN_SITEPATH=$3
 
 if [ ! -z "$4" ]; then
     SITETYPE="sub"
-    MASTERPATH="$4"
+    MASTERSITE="$4"
 fi
 
 if [  -e "$SITEPATH" ]; then

--- a/files/d7_migrate.sh
+++ b/files/d7_migrate.sh
@@ -8,30 +8,26 @@ if [ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ] ; then
     cat <<USAGE
 d7_migrate.sh migrates a site between hosts.
 
-Usage: d7_migrate.sh \$SITEPATH \$SRCHOST \$ORIGIN_SITEPATH [\$SITETYPE]
+Usage: d7_migrate.sh \$SITEPATH \$SRCHOST \$ORIGIN_SITEPATH [\$MASTERSITE]
 
 \$SITEPATH          local Drupal path for new migrated site
 \$SRCHOST           host of site to migrate    
 \$ORIGIN_SITEPATH   path of site to migrate on \$SRCHOST  
-\$SITETYPE  optional argument.  master (default), or sub. 
+\$MASTERSITE        optional argument.  master (default), or sub. 
 USAGE
     exit 1;
 fi
 
 SITEPATH=$1
+MASTERPATH=${SITEPATH}
+SITETYPE=master
+
 SRCHOST=$2
 ORIGIN_SITEPATH=$3
 
 if [ ! -z "$4" ]; then
-
-
-    if [ ! "$4" == "master"  -o  "$4" == "sub"  ]; then
-	  echo "Bad site type:  $4"
-	  exit 1
-    fi
-
-    SITETYPE="$4"    
-
+    SITETYPE="sub"
+    MASTERPATH="$4"
 fi
 
 if [  -e "$SITEPATH" ]; then
@@ -42,7 +38,7 @@ fi
 echo "Migrating site to ${SITEPATH} from ${SRCHOST} path ${ORIGIN_SITEPATH}."
 
 # Build an empty site 
-d7_init.sh "$SITEPATH" "$SITETYPE" || exit 1
+d7_init.sh "$SITEPATH" "$MASTERSITE" || exit 1
 
 echo "Copying makefiles!"
 for file in "site.make" "site.make.uri" ; do

--- a/files/d7_migrate.sh
+++ b/files/d7_migrate.sh
@@ -4,16 +4,16 @@
 source /opt/d7/etc/d7_conf.sh
 
 ## Require arguments
-if [ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ] ; then 
+if [ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ] ; then
     cat <<USAGE
 d7_migrate.sh migrates a site between hosts.
 
-Usage: d7_migrate.sh \$SITEPATH \$SRCHOST \$ORIGIN_SITEPATH [\$MASTERSITE]
+Usage: d7_migrate.sh \$SITEPATH \$SRCHOST \$ORIGIN_SITEPATH [\$MASTERPATH]
 
-\$SITEPATH          local Drupal path for new migrated site
-\$SRCHOST           host of site to migrate    
-\$ORIGIN_SITEPATH   path of site to migrate on \$SRCHOST  
-\$MASTERSITE        optional argument.  master (default), or sub. 
+\$SITEPATH          local path for Drupal site (eg. /srv/example).
+\$SRCHOST           host of site to migrate
+\$ORIGIN_SITEPATH   remote path of site to migrate on \$SRCHOST
+\$MASTERPATH        (optional) local path to master site
 USAGE
     exit 1;
 fi
@@ -37,7 +37,7 @@ fi
 
 echo "Migrating site to ${SITEPATH} from ${SRCHOST} path ${ORIGIN_SITEPATH}."
 
-# Build an empty site 
+# Build an empty site
 d7_init.sh "$SITEPATH" "$MASTERSITE" || exit 1
 
 echo "Copying makefiles!"

--- a/files/d7_sync.sh
+++ b/files/d7_sync.sh
@@ -10,12 +10,12 @@ d7_synch.sh syncs content files and database from a remote site to a
 local Drupal site, creating it if it doesn't exist.
 
 Usage: d7_sync.sh \$SITEPATH \$SRCHOST [\$ORIGIN_SITEPATH]
-    
+
 \$SITEPATH         local target of the sync
-\$SRCHOST          host from which to sync  
-\$ORIGIN_SITEPATH  optional argument, path to sync on the remote host. 
-                   \$SITEPATH will be used if a different $ORIGIN_SITEPATH 
-                   is not specified. 
+\$SRCHOST          host from which to sync
+\$ORIGIN_SITEPATH  optional argument, path to sync on the remote host.
+		   \$SITEPATH will be used if a different $ORIGIN_SITEPATH
+		   is not specified.
 USAGE
 
   exit 1;
@@ -24,7 +24,7 @@ fi
 SITEPATH=$1
 SRCHOST=$2
 if [ ! -z "$3" ]; then
-    ORIGIN_SITEPATH=$3 
+    ORIGIN_SITEPATH=$3
 else
     ORIGIN_SITEPATH=$SITEPATH
 fi
@@ -40,22 +40,22 @@ if [[ ! -e $SITEPATH ]]; then
     d7_init.sh "$SITEPATH" || exit 1;
 fi
 
-
 ## Drupal default site dir is ~ 6770
 d7_perms.sh --sticky "$SITEPATH/default"
 
 ## Make the sync directory
+echo "Prepare sync destination."
 sudo -u apache mkdir -p "$SITEPATH/default/files_sync"
-echo "Setting permissions for synced files."
 d7_perms.sh --sticky "$SITEPATH/default/files_sync"
 
 ## Sync Files to writable directory (sudo would break ssh)
+echo "Begin syncing."
 RSOPTS="--verbose --recursive --links  --compress"
-rsync  $RSOPTS  "$SRCHOST:$ORIGIN_SITEPATH/default/files/" "$SITEPATH/default/files_sync" | while read $RSFILE; do printf "."; done; 
+rsync  $RSOPTS  "$SRCHOST:$ORIGIN_SITEPATH/default/files/" "$SITEPATH/default/files_sync" | while read $RSFILE; do printf "."; done;
 echo "Files synced."
 
 ## Set perms for sync directory
-echo "Setting permissions for synced files."
+echo "Set permissions for synced files."
 d7_perms.sh --sticky "$SITEPATH/default/files_sync"
 
 ## Now that everything is ready, swap in the synced files

--- a/files/d7_update.sh
+++ b/files/d7_update.sh
@@ -21,14 +21,14 @@ echo "Processing $SITEPATH"
 
 
 # Check for available updates
-UPDATELIST="$(drush pm-updatestatus --security-only --pipe)"
+UPDATELIST=$(drush -r "${SITEPATH}/drupal" pm-updatestatus --security-only --pipe)
 if [ "" == "${UPDATELIST}" ] ; then
     echo "No security updates available"
-    exit 1
+    exit 0
 fi
 
 
-## Dump DB before touching anything
+## dump DB before touching anything
 d7_dump.sh "$SITEPATH" || exit 1;
 
 ## Enable update manager.
@@ -41,7 +41,7 @@ sudo -u apache drush up -y --security-only -r "$SITEPATH/drupal"  --no-backup  |
 sudo -u apache drush -y dis update -r "$SITEPATH/drupal" || exit 1;
 
 ## Make sure any updated php is readable
-d7_perms_fix.sh "$SITEPATH"
+d7_perms.sh "$SITEPATH/drupal"
 
 ## Make sure new code is loaded
 d7_cc.sh "$SITEPATH"

--- a/files/d7_update.sh
+++ b/files/d7_update.sh
@@ -8,7 +8,7 @@ if [  -z "$1" ]; then
 d7_update.sh applies security (only) updates to a drupal site.
 
 Usage: d7_update.sh \$SITEPATH
-            
+
 \$SITEPATH   Drupal site to update.
 USAGE
 
@@ -18,6 +18,15 @@ fi
 SITEPATH=$1
 
 echo "Processing $SITEPATH"
+
+
+# Check for available updates
+UPDATELIST="$(drush pm-updatestatus --security-only --pipe)"
+if [ "" == "${UPDATELIST}" ] ; then
+    echo "No security updates available"
+    exit 1
+fi
+
 
 ## Dump DB before touching anything
 d7_dump.sh "$SITEPATH" || exit 1;
@@ -31,12 +40,11 @@ sudo -u apache drush up -y --security-only -r "$SITEPATH/drupal"  --no-backup  |
 ## Disable update manager; no need to leave it phoning home.
 sudo -u apache drush -y dis update -r "$SITEPATH/drupal" || exit 1;
 
-## Clear the caches
+## Make sure any updated php is readable
+d7_perms_fix.sh "$SITEPATH"
+
+## Make sure new code is loaded
 d7_cc.sh "$SITEPATH"
 
 ## Avoid a known performance-crusher in our environment
 sudo -u apache drush eval 'variable_set('drupal_http_request_fails', 0)' -r "$SITEPATH/drupal" || exit 1;
-
-## settings.php is protected.
-sudo -u apache chmod ug=r,o= "$SITEPATH/default/settings.php" 2>/dev/null || \
-chmod ug=r,o= "$SITEPATH/default/settings.php"

--- a/files/drupal-files.include
+++ b/files/drupal-files.include
@@ -1,0 +1,23 @@
+# oulib settings for Drupal files
+<Directory "/srv/*/drupal/sites/default/files">
+  Options None
+  Options +FollowSymLinks
+
+  # Set the catch-all handler to prevent scripts from being executed.
+  SetHandler Drupal_Security_Do_Not_Remove_See_SA_2006_006
+
+  # Override the handler again if we're run later in the evaluation list.
+  <Files *>
+    SetHandler Drupal_Security_Do_Not_Remove_See_SA_2013_003
+  </Files>
+
+  # If we know how to do it safely, disable the PHP engine entirely.
+  <IfModule mod_php5.c>
+    php_flag engine off
+  </IfModule>
+</Directory>
+
+# oulib settings for Drupal files
+<Directory "/srv/*/drupal/sites/default/files/private">
+  Deny from all
+</Directory>

--- a/files/drupal.include
+++ b/files/drupal.include
@@ -1,0 +1,149 @@
+#
+# Apache/PHP/Drupal settings:
+#
+
+# Protect files and directories from prying eyes.
+<FilesMatch "\.(engine|inc|info|install|make|module|profile|test|po|sh|.*sql|theme|tpl(\.php)?|xtmpl)(~|\.sw[op]|\.bak|\.orig|\.save)?$|^(\..*|Entries.*|Repository|Root|Tag|Template|composer\.(json|lock))$|^#.*#$|\.php(~|\.sw[op]|\.bak|\.orig\.save)$">
+  Order allow,deny
+</FilesMatch>
+
+# Don't show directory listings for URLs which map to a directory.
+Options -Indexes
+
+# Follow symbolic links in this directory.
+Options +FollowSymLinks
+
+# Make Drupal handle any 404 errors.
+ErrorDocument 404 /index.php
+
+# Set the default handler.
+DirectoryIndex index.php index.html index.htm
+
+# Override PHP settings that cannot be changed at runtime. See
+# sites/default/default.settings.php and drupal_environment_initialize() in
+# includes/bootstrap.inc for settings that can be changed at runtime.
+
+# PHP 5, Apache 1 and 2.
+<IfModule mod_php5.c>
+  php_flag magic_quotes_gpc                 off
+  php_flag magic_quotes_sybase              off
+  php_flag register_globals                 off
+  php_flag session.auto_start               off
+  php_value mbstring.http_input             pass
+  php_value mbstring.http_output            pass
+  php_flag mbstring.encoding_translation    off
+</IfModule>
+
+# Requires mod_expires to be enabled.
+<IfModule mod_expires.c>
+  # Enable expirations.
+  ExpiresActive On
+
+  # Cache all files for 2 weeks after access (A).
+  ExpiresDefault A1209600
+
+  <FilesMatch \.php$>
+    # Do not allow PHP scripts to be cached unless they explicitly send cache
+    # headers themselves. Otherwise all scripts would have to overwrite the
+    # headers set by mod_expires if they want another caching behavior. This may
+    # fail if an error occurs early in the bootstrap process, and it may cause
+    # problems if a non-Drupal PHP file is installed in a subdirectory.
+    ExpiresActive Off
+  </FilesMatch>
+</IfModule>
+
+# Various rewrite rules.
+<IfModule mod_rewrite.c>
+  RewriteEngine on
+
+  # Set "protossl" to "s" if we were accessed via https://.  This is used later
+  # if you enable "www." stripping or enforcement, in order to ensure that
+  # you don't bounce between http and https.
+  RewriteRule ^ - [E=protossl]
+  RewriteCond %{HTTPS} on
+  RewriteRule ^ - [E=protossl:s]
+
+  # Make sure Authorization HTTP header is available to PHP
+  # even when running as CGI or FastCGI.
+  RewriteRule ^ - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+
+  # Block access to "hidden" directories whose names begin with a period. This
+  # includes directories used by version control systems such as Subversion or
+  # Git to store control files. Files whose names begin with a period, as well
+  # as the control files used by CVS, are protected by the FilesMatch directive
+  # above.
+  #
+  # NOTE: This only works when mod_rewrite is loaded. Without mod_rewrite, it is
+  # not possible to block access to entire directories from .htaccess, because
+  # <DirectoryMatch> is not allowed here.
+  #
+  # If you do not have mod_rewrite installed, you should remove these
+  # directories from your webroot or otherwise protect them from being
+  # downloaded.
+  RewriteRule "(^|/)\." - [F]
+
+  # If your site can be accessed both with and without the 'www.' prefix, you
+  # can use one of the following settings to redirect users to your preferred
+  # URL, either WITH or WITHOUT the 'www.' prefix. Choose ONLY one option:
+  #
+  # To redirect all users to access the site WITH the 'www.' prefix,
+  # (http://example.com/... will be redirected to http://www.example.com/...)
+  # uncomment the following:
+  # RewriteCond %{HTTP_HOST} .
+  # RewriteCond %{HTTP_HOST} !^www\. [NC]
+  # RewriteRule ^ http%{ENV:protossl}://www.%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
+  #
+  # To redirect all users to access the site WITHOUT the 'www.' prefix,
+  # (http://www.example.com/... will be redirected to http://example.com/...)
+  # uncomment the following:
+  # RewriteCond %{HTTP_HOST} ^www\.(.+)$ [NC]
+  # RewriteRule ^ http%{ENV:protossl}://%1%{REQUEST_URI} [L,R=301]
+
+  # Modify the RewriteBase if you are using Drupal in a subdirectory or in a
+  # VirtualDocumentRoot and the rewrite rules are not working properly.
+  # For example if your site is at http://example.com/drupal uncomment and
+  # modify the following line:
+  # RewriteBase /drupal
+  #
+  # If your site is running in a VirtualDocumentRoot at http://example.com/,
+  # uncomment the following line:
+  # RewriteBase /
+
+  # Pass all requests not referring directly to files in the filesystem to
+  # index.php. Clean URLs are handled in drupal_environment_initialize().
+  RewriteCond %{REQUEST_FILENAME} !-f
+  RewriteCond %{REQUEST_FILENAME} !-d
+  RewriteCond %{REQUEST_URI} !=/favicon.ico
+  RewriteRule ^ index.php [L]
+
+  # Rules to correctly serve gzip compressed CSS and JS files.
+  # Requires both mod_rewrite and mod_headers to be enabled.
+  <IfModule mod_headers.c>
+    # Serve gzip compressed CSS files if they exist and the client accepts gzip.
+    RewriteCond %{HTTP:Accept-encoding} gzip
+    RewriteCond %{REQUEST_FILENAME}\.gz -s
+    RewriteRule ^(.*)\.css $1\.css\.gz [QSA]
+
+    # Serve gzip compressed JS files if they exist and the client accepts gzip.
+    RewriteCond %{HTTP:Accept-encoding} gzip
+    RewriteCond %{REQUEST_FILENAME}\.gz -s
+    RewriteRule ^(.*)\.js $1\.js\.gz [QSA]
+
+    # Serve correct content types, and prevent mod_deflate double gzip.
+    RewriteRule \.css\.gz$ - [T=text/css,E=no-gzip:1]
+    RewriteRule \.js\.gz$ - [T=text/javascript,E=no-gzip:1]
+
+    <FilesMatch "(\.js\.gz|\.css\.gz)$">
+      # Serve correct encoding type.
+      Header set Content-Encoding gzip
+      # Force proxies to cache gzipped & non-gzipped css/js files separately.
+      Header append Vary Accept-Encoding
+    </FilesMatch>
+  </IfModule>
+</IfModule>
+
+# Add headers to all responses.
+<IfModule mod_headers.c>
+  # Disable content sniffing, since it's an attack vector.
+  Header always set X-Content-Type-Options nosniff
+</IfModule>

--- a/files/drupal.include
+++ b/files/drupal.include
@@ -147,3 +147,28 @@ DirectoryIndex index.php index.html index.htm
   # Disable content sniffing, since it's an attack vector.
   Header always set X-Content-Type-Options nosniff
 </IfModule>
+
+
+# oulib settings for Drupal files
+<Directory "/srv/*/drupal/sites/default/files">
+  Options None
+  Options +FollowSymLinks
+
+  # Set the catch-all handler to prevent scripts from being executed.
+  SetHandler Drupal_Security_Do_Not_Remove_See_SA_2006_006
+
+  # Override the handler again if we're run later in the evaluation list.
+  <Files *>
+    SetHandler Drupal_Security_Do_Not_Remove_See_SA_2013_003
+  </Files>
+
+  # If we know how to do it safely, disable the PHP engine entirely.
+  <IfModule mod_php5.c>
+    php_flag engine off
+  </IfModule>
+</Directory>
+
+# oulib settings for Drupal files
+<Directory "/srv/*/drupal/sites/default/files/private">
+  Deny from all
+</Directory>

--- a/tasks/assets.yml
+++ b/tasks/assets.yml
@@ -113,6 +113,14 @@
     group: wheel
     mode: 0444
 
+- name: Install php.ini
+  template:
+    src: drush.ini.j2
+    dest: /etc/php.ini
+    mode: 0644
+    owner: root
+    group: wheel    
+
 - name: Ensure /etc/drush exists
   file:
     path: /etc/drush

--- a/tasks/assets.yml
+++ b/tasks/assets.yml
@@ -36,7 +36,7 @@
   copy:
     src: drupal.include
     dest: /etc/httpd/conf.d/
-    mode: 0755
+    mode: 0644
     owner: root
     group: wheel
 

--- a/tasks/assets.yml
+++ b/tasks/assets.yml
@@ -32,6 +32,14 @@
     - d7_sync.sh
     - d7_update.sh
 
+- name: Install Drupal Apache include
+  copy:
+    src: drupal.include
+    dest: /etc/httpd/conf.d/
+    mode: 0755
+    owner: root
+    group: wheel
+
 - name: Install cron scripts
   copy:
     src: "{{ item }}"
@@ -104,5 +112,3 @@
     owner: apache
     group: wheel
     mode: 0444
-
-    

--- a/tasks/assets.yml
+++ b/tasks/assets.yml
@@ -32,13 +32,16 @@
     - d7_sync.sh
     - d7_update.sh
 
-- name: Install Drupal Apache include
+- name: Install Drupal Apache includes
   copy:
-    src: drupal.include
+    src: "{{ item }}"
     dest: /etc/httpd/conf.d/
     mode: 0644
     owner: root
     group: wheel
+  with_items:
+    - drupal.include
+    - drupal-files.include
 
 - name: Install cron scripts
   copy:
@@ -115,7 +118,7 @@
 
 - name: Install php.ini
   template:
-    src: drush.ini.j2
+    src: php.ini.j2
     dest: /etc/php.ini
     mode: 0644
     owner: root

--- a/tasks/assets.yml
+++ b/tasks/assets.yml
@@ -115,7 +115,7 @@
 
 - name: Install php.ini
   template:
-    src: drush.ini.j2
+    src: php.ini.j2
     dest: /etc/php.ini
     mode: 0644
     owner: root

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -16,32 +16,6 @@
     state: present
     dest: /etc/httpd/conf/httpd.conf
     line: "IncludeOptional \"/srv/*/etc/*.conf\""
-- name: Set upload_max_filesize
-  replace:
-    dest: /etc/php.ini
-    regexp: >
-      ^upload_max_filesize = 2M$
-    replace: "upload_max_filesize = 64M"
-- name: Set post_max_size
-  replace:
-    dest: /etc/php.ini
-    regexp: >
-      ^post_max_size = 8M$
-    replace: "post_max_size = 70M"
-
-- name: Set php.ini memory_limit
-  replace:
-    dest: /etc/php.ini
-    regexp: >
-      ^memory_limit = .*$
-    replace: "memory_limit = {{ d7_memory_limit }}"
-    
-- name: Set PHP timezone
-  replace:
-    dest: /etc/php.ini
-    regexp: >
-      ^;date.timezone =$
-    replace: "date.timezone = America/Chicago"
 
 - name: Ensure /etc/profile.d/d7-ops.sh exists
   file:

--- a/templates/php.ini.j2
+++ b/templates/php.ini.j2
@@ -1421,7 +1421,7 @@ session.gc_probability = {{ d7_session_gc_probability }}
 ; Development Value: 1000
 ; Production Value: 1000
 ; http://php.net/session.gc-divisor
-session.gc_divisor = {{ d7_session_gc_divisior }}
+session.gc_divisor = {{ d7_session_gc_divisor }}
 
 ; After this number of seconds, stored data will be seen as 'garbage' and
 ; cleaned up by the garbage collection process.

--- a/templates/php.ini.j2
+++ b/templates/php.ini.j2
@@ -1,0 +1,1796 @@
+[PHP]
+
+;;;;;;;;;;;;;;;;;;;
+; About php.ini   ;
+;;;;;;;;;;;;;;;;;;;
+; PHP's initialization file, generally called php.ini, is responsible for
+; configuring many of the aspects of PHP's behavior.
+
+; PHP attempts to find and load this configuration from a number of locations.
+; The following is a summary of its search order:
+; 1. SAPI module specific location.
+; 2. The PHPRC environment variable. (As of PHP 5.2.0)
+; 3. A number of predefined registry keys on Windows (As of PHP 5.2.0)
+; 4. Current working directory (except CLI)
+; 5. The web server's directory (for SAPI modules), or directory of PHP
+; (otherwise in Windows)
+; 6. The directory from the --with-config-file-path compile time option, or the
+; Windows directory (C:\windows or C:\winnt)
+; See the PHP docs for more specific information.
+; http://php.net/configuration.file
+
+; The syntax of the file is extremely simple.  Whitespace and lines
+; beginning with a semicolon are silently ignored (as you probably guessed).
+; Section headers (e.g. [Foo]) are also silently ignored, even though
+; they might mean something in the future.
+
+; Directives following the section heading [PATH=/www/mysite] only
+; apply to PHP files in the /www/mysite directory.  Directives
+; following the section heading [HOST=www.example.com] only apply to
+; PHP files served from www.example.com.  Directives set in these
+; special sections cannot be overridden by user-defined INI files or
+; at runtime. Currently, [PATH=] and [HOST=] sections only work under
+; CGI/FastCGI.
+; http://php.net/ini.sections
+
+; Directives are specified using the following syntax:
+; directive = value
+; Directive names are *case sensitive* - foo=bar is different from FOO=bar.
+; Directives are variables used to configure PHP or PHP extensions.
+; There is no name validation.  If PHP can't find an expected
+; directive because it is not set or is mistyped, a default value will be used.
+
+; The value can be a string, a number, a PHP constant (e.g. E_ALL or M_PI), one
+; of the INI constants (On, Off, True, False, Yes, No and None) or an expression
+; (e.g. E_ALL & ~E_NOTICE), a quoted string ("bar"), or a reference to a
+; previously set variable or directive (e.g. ${foo})
+
+; Expressions in the INI file are limited to bitwise operators and parentheses:
+; |  bitwise OR
+; ^  bitwise XOR
+; &  bitwise AND
+; ~  bitwise NOT
+; !  boolean NOT
+
+; Boolean flags can be turned on using the values 1, On, True or Yes.
+; They can be turned off using the values 0, Off, False or No.
+
+; An empty string can be denoted by simply not writing anything after the equal
+; sign, or by using the None keyword:
+
+;  foo =         ; sets foo to an empty string
+;  foo = None    ; sets foo to an empty string
+;  foo = "None"  ; sets foo to the string 'None'
+
+; If you use constants in your value, and these constants belong to a
+; dynamically loaded extension (either a PHP extension or a Zend extension),
+; you may only use these constants *after* the line that loads the extension.
+
+;;;;;;;;;;;;;;;;;;;
+; About this file ;
+;;;;;;;;;;;;;;;;;;;
+; PHP comes packaged with two INI files. One that is recommended to be used
+; in production environments and one that is recommended to be used in
+; development environments.
+
+; php.ini-production contains settings which hold security, performance and
+; best practices at its core. But please be aware, these settings may break
+; compatibility with older or less security conscience applications. We
+; recommending using the production ini in production and testing environments.
+
+; php.ini-development is very similar to its production variant, except it's
+; much more verbose when it comes to errors. We recommending using the
+; development version only in development environments as errors shown to
+; application users can inadvertently leak otherwise secure information.
+
+;;;;;;;;;;;;;;;;;;;
+; Quick Reference ;
+;;;;;;;;;;;;;;;;;;;
+; The following are all the settings which are different in either the production
+; or development versions of the INIs with respect to PHP's default behavior.
+; Please see the actual settings later in the document for more details as to why
+; we recommend these changes in PHP's behavior.
+
+; display_errors
+;   Default Value: On
+;   Development Value: On
+;   Production Value: Off
+
+; display_startup_errors
+;   Default Value: Off
+;   Development Value: On
+;   Production Value: Off
+
+; error_reporting
+;   Default Value: E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED
+;   Development Value: E_ALL
+;   Production Value: E_ALL & ~E_DEPRECATED & ~E_STRICT
+
+; html_errors
+;   Default Value: On
+;   Development Value: On
+;   Production value: On
+
+; log_errors
+;   Default Value: Off
+;   Development Value: On
+;   Production Value: On
+
+; max_input_time
+;   Default Value: -1 (Unlimited)
+;   Development Value: 60 (60 seconds)
+;   Production Value: 60 (60 seconds)
+
+; output_buffering
+;   Default Value: Off
+;   Development Value: 4096
+;   Production Value: 4096
+
+; register_argc_argv
+;   Default Value: On
+;   Development Value: Off
+;   Production Value: Off
+
+; request_order
+;   Default Value: None
+;   Development Value: "GP"
+;   Production Value: "GP"
+
+; session.bug_compat_42
+;   Default Value: On
+;   Development Value: On
+;   Production Value: Off
+
+; session.bug_compat_warn
+;   Default Value: On
+;   Development Value: On
+;   Production Value: Off
+
+; session.gc_divisor
+;   Default Value: 100
+;   Development Value: 1000
+;   Production Value: 1000
+
+; session.hash_bits_per_character
+;   Default Value: 4
+;   Development Value: 5
+;   Production Value: 5
+
+; short_open_tag
+;   Default Value: On
+;   Development Value: Off
+;   Production Value: Off
+
+; track_errors
+;   Default Value: Off
+;   Development Value: On
+;   Production Value: Off
+
+; url_rewriter.tags
+;   Default Value: "a=href,area=href,frame=src,form=,fieldset="
+;   Development Value: "a=href,area=href,frame=src,input=src,form=fakeentry"
+;   Production Value: "a=href,area=href,frame=src,input=src,form=fakeentry"
+
+; variables_order
+;   Default Value: "EGPCS"
+;   Development Value: "GPCS"
+;   Production Value: "GPCS"
+
+;;;;;;;;;;;;;;;;;;;;
+; php.ini Options  ;
+;;;;;;;;;;;;;;;;;;;;
+; Name for user-defined php.ini (.htaccess) files. Default is ".user.ini"
+;user_ini.filename = ".user.ini"
+
+; To disable this feature set this option to empty value
+;user_ini.filename =
+
+; TTL for user-defined php.ini files (time-to-live) in seconds. Default is 300 seconds (5 minutes)
+;user_ini.cache_ttl = 300
+
+;;;;;;;;;;;;;;;;;;;;
+; Language Options ;
+;;;;;;;;;;;;;;;;;;;;
+
+; Enable the PHP scripting language engine under Apache.
+; http://php.net/engine
+engine = On
+
+; This directive determines whether or not PHP will recognize code between
+; <? and ?> tags as PHP source which should be processed as such. It's been
+; recommended for several years that you not use the short tag "short cut" and
+; instead to use the full <?php and ?> tag combination. With the wide spread use
+; of XML and use of these tags by other languages, the server can become easily
+; confused and end up parsing the wrong code in the wrong context. But because
+; this short cut has been a feature for such a long time, it's currently still
+; supported for backwards compatibility, but we recommend you don't use them.
+; Default Value: On
+; Development Value: Off
+; Production Value: Off
+; http://php.net/short-open-tag
+short_open_tag = Off
+
+; Allow ASP-style <% %> tags.
+; http://php.net/asp-tags
+asp_tags = Off
+
+; The number of significant digits displayed in floating point numbers.
+; http://php.net/precision
+precision = 14
+
+; Output buffering is a mechanism for controlling how much output data
+; (excluding headers and cookies) PHP should keep internally before pushing that
+; data to the client. If your application's output exceeds this setting, PHP
+; will send that data in chunks of roughly the size you specify.
+; Turning on this setting and managing its maximum buffer size can yield some
+; interesting side-effects depending on your application and web server.
+; You may be able to send headers and cookies after you've already sent output
+; through print or echo. You also may see performance benefits if your server is
+; emitting less packets due to buffered output versus PHP streaming the output
+; as it gets it. On production servers, 4096 bytes is a good setting for performance
+; reasons.
+; Note: Output buffering can also be controlled via Output Buffering Control
+;   functions.
+; Possible Values:
+;   On = Enabled and buffer is unlimited. (Use with caution)
+;   Off = Disabled
+;   Integer = Enables the buffer and sets its maximum size in bytes.
+; Note: This directive is hardcoded to Off for the CLI SAPI
+; Default Value: Off
+; Development Value: 4096
+; Production Value: 4096
+; http://php.net/output-buffering
+output_buffering = 4096
+
+; You can redirect all of the output of your scripts to a function.  For
+; example, if you set output_handler to "mb_output_handler", character
+; encoding will be transparently converted to the specified encoding.
+; Setting any output handler automatically turns on output buffering.
+; Note: People who wrote portable scripts should not depend on this ini
+;   directive. Instead, explicitly set the output handler using ob_start().
+;   Using this ini directive may cause problems unless you know what script
+;   is doing.
+; Note: You cannot use both "mb_output_handler" with "ob_iconv_handler"
+;   and you cannot use both "ob_gzhandler" and "zlib.output_compression".
+; Note: output_handler must be empty if this is set 'On' !!!!
+;   Instead you must use zlib.output_handler.
+; http://php.net/output-handler
+;output_handler =
+
+; Transparent output compression using the zlib library
+; Valid values for this option are 'off', 'on', or a specific buffer size
+; to be used for compression (default is 4KB)
+; Note: Resulting chunk size may vary due to nature of compression. PHP
+;   outputs chunks that are few hundreds bytes each as a result of
+;   compression. If you prefer a larger chunk size for better
+;   performance, enable output_buffering in addition.
+; Note: You need to use zlib.output_handler instead of the standard
+;   output_handler, or otherwise the output will be corrupted.
+; http://php.net/zlib.output-compression
+zlib.output_compression = Off
+
+; http://php.net/zlib.output-compression-level
+;zlib.output_compression_level = -1
+
+; You cannot specify additional output handlers if zlib.output_compression
+; is activated here. This setting does the same as output_handler but in
+; a different order.
+; http://php.net/zlib.output-handler
+;zlib.output_handler =
+
+; Implicit flush tells PHP to tell the output layer to flush itself
+; automatically after every output block.  This is equivalent to calling the
+; PHP function flush() after each and every call to print() or echo() and each
+; and every HTML block.  Turning this option on has serious performance
+; implications and is generally recommended for debugging purposes only.
+; http://php.net/implicit-flush
+; Note: This directive is hardcoded to On for the CLI SAPI
+implicit_flush = Off
+
+; The unserialize callback function will be called (with the undefined class'
+; name as parameter), if the unserializer finds an undefined class
+; which should be instantiated. A warning appears if the specified function is
+; not defined, or if the function doesn't include/implement the missing class.
+; So only set this entry, if you really want to implement such a
+; callback-function.
+unserialize_callback_func =
+
+; When floats & doubles are serialized store serialize_precision significant
+; digits after the floating point. The default value ensures that when floats
+; are decoded with unserialize, the data will remain the same.
+serialize_precision = 17
+
+; open_basedir, if set, limits all file operations to the defined directory
+; and below.  This directive makes most sense if used in a per-directory
+; or per-virtualhost web server configuration file. This directive is
+; *NOT* affected by whether Safe Mode is turned On or Off.
+; http://php.net/open-basedir
+;open_basedir =
+
+; This directive allows you to disable certain functions for security reasons.
+; It receives a comma-delimited list of function names. This directive is
+; *NOT* affected by whether Safe Mode is turned On or Off.
+; http://php.net/disable-functions
+disable_functions =
+
+; This directive allows you to disable certain classes for security reasons.
+; It receives a comma-delimited list of class names. This directive is
+; *NOT* affected by whether Safe Mode is turned On or Off.
+; http://php.net/disable-classes
+disable_classes =
+
+; Colors for Syntax Highlighting mode.  Anything that's acceptable in
+; <span style="color: ???????"> would work.
+; http://php.net/syntax-highlighting
+;highlight.string  = #DD0000
+;highlight.comment = #FF9900
+;highlight.keyword = #007700
+;highlight.default = #0000BB
+;highlight.html    = #000000
+
+; If enabled, the request will be allowed to complete even if the user aborts
+; the request. Consider enabling it if executing long requests, which may end up
+; being interrupted by the user or a browser timing out. PHP's default behavior
+; is to disable this feature.
+; http://php.net/ignore-user-abort
+;ignore_user_abort = On
+
+; Determines the size of the realpath cache to be used by PHP. This value should
+; be increased on systems where PHP opens many files to reflect the quantity of
+; the file operations performed.
+; http://php.net/realpath-cache-size
+;realpath_cache_size = 16k
+
+; Duration of time, in seconds for which to cache realpath information for a given
+; file or directory. For systems with rarely changing files, consider increasing this
+; value.
+; http://php.net/realpath-cache-ttl
+;realpath_cache_ttl = 120
+
+; Enables or disables the circular reference collector.
+; http://php.net/zend.enable-gc
+zend.enable_gc = On
+
+; If enabled, scripts may be written in encodings that are incompatible with
+; the scanner.  CP936, Big5, CP949 and Shift_JIS are the examples of such
+; encodings.  To use this feature, mbstring extension must be enabled.
+; Default: Off
+;zend.multibyte = Off
+
+; Allows to set the default encoding for the scripts.  This value will be used
+; unless "declare(encoding=...)" directive appears at the top of the script.
+; Only affects if zend.multibyte is set.
+; Default: ""
+;zend.script_encoding =
+
+;;;;;;;;;;;;;;;;;
+; Miscellaneous ;
+;;;;;;;;;;;;;;;;;
+
+; Decides whether PHP may expose the fact that it is installed on the server
+; (e.g. by adding its signature to the Web server header).  It is no security
+; threat in any way, but it makes it possible to determine whether you use PHP
+; on your server or not.
+; http://php.net/expose-php
+expose_php = On
+
+;;;;;;;;;;;;;;;;;;;
+; Resource Limits ;
+;;;;;;;;;;;;;;;;;;;
+
+; Maximum execution time of each script, in seconds
+; http://php.net/max-execution-time
+; Note: This directive is hardcoded to 0 for the CLI SAPI
+max_execution_time = 30
+
+; Maximum amount of time each script may spend parsing request data. It's a good
+; idea to limit this time on productions servers in order to eliminate unexpectedly
+; long running scripts.
+; Note: This directive is hardcoded to -1 for the CLI SAPI
+; Default Value: -1 (Unlimited)
+; Development Value: 60 (60 seconds)
+; Production Value: 60 (60 seconds)
+; http://php.net/max-input-time
+max_input_time = 60
+
+; Maximum input variable nesting level
+; http://php.net/max-input-nesting-level
+;max_input_nesting_level = 64
+
+; How many GET/POST/COOKIE input variables may be accepted
+; max_input_vars = 1000
+
+; Maximum amount of memory a script may consume (128MB)
+; http://php.net/memory-limit
+memory_limit = {{ d7_memory_limit }}
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Error handling and logging ;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+; This directive informs PHP of which errors, warnings and notices you would like
+; it to take action for. The recommended way of setting values for this
+; directive is through the use of the error level constants and bitwise
+; operators. The error level constants are below here for convenience as well as
+; some common settings and their meanings.
+; By default, PHP is set to take action on all errors, notices and warnings EXCEPT
+; those related to E_NOTICE and E_STRICT, which together cover best practices and
+; recommended coding standards in PHP. For performance reasons, this is the
+; recommend error reporting setting. Your production server shouldn't be wasting
+; resources complaining about best practices and coding standards. That's what
+; development servers and development settings are for.
+; Note: The php.ini-development file has this setting as E_ALL. This
+; means it pretty much reports everything which is exactly what you want during
+; development and early testing.
+;
+; Error Level Constants:
+; E_ALL             - All errors and warnings (includes E_STRICT as of PHP 5.4.0)
+; E_ERROR           - fatal run-time errors
+; E_RECOVERABLE_ERROR  - almost fatal run-time errors
+; E_WARNING         - run-time warnings (non-fatal errors)
+; E_PARSE           - compile-time parse errors
+; E_NOTICE          - run-time notices (these are warnings which often result
+;                     from a bug in your code, but it's possible that it was
+;                     intentional (e.g., using an uninitialized variable and
+;                     relying on the fact it's automatically initialized to an
+;                     empty string)
+; E_STRICT          - run-time notices, enable to have PHP suggest changes
+;                     to your code which will ensure the best interoperability
+;                     and forward compatibility of your code
+; E_CORE_ERROR      - fatal errors that occur during PHP's initial startup
+; E_CORE_WARNING    - warnings (non-fatal errors) that occur during PHP's
+;                     initial startup
+; E_COMPILE_ERROR   - fatal compile-time errors
+; E_COMPILE_WARNING - compile-time warnings (non-fatal errors)
+; E_USER_ERROR      - user-generated error message
+; E_USER_WARNING    - user-generated warning message
+; E_USER_NOTICE     - user-generated notice message
+; E_DEPRECATED      - warn about code that will not work in future versions
+;                     of PHP
+; E_USER_DEPRECATED - user-generated deprecation warnings
+;
+; Common Values:
+;   E_ALL (Show all errors, warnings and notices including coding standards.)
+;   E_ALL & ~E_NOTICE  (Show all errors, except for notices)
+;   E_ALL & ~E_NOTICE & ~E_STRICT  (Show all errors, except for notices and coding standards warnings.)
+;   E_COMPILE_ERROR|E_RECOVERABLE_ERROR|E_ERROR|E_CORE_ERROR  (Show only errors)
+; Default Value: E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED
+; Development Value: E_ALL
+; Production Value: E_ALL & ~E_DEPRECATED & ~E_STRICT
+; http://php.net/error-reporting
+error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
+
+; This directive controls whether or not and where PHP will output errors,
+; notices and warnings too. Error output is very useful during development, but
+; it could be very dangerous in production environments. Depending on the code
+; which is triggering the error, sensitive information could potentially leak
+; out of your application such as database usernames and passwords or worse.
+; It's recommended that errors be logged on production servers rather than
+; having the errors sent to STDOUT.
+; Possible Values:
+;   Off = Do not display any errors
+;   stderr = Display errors to STDERR (affects only CGI/CLI binaries!)
+;   On or stdout = Display errors to STDOUT
+; Default Value: On
+; Development Value: On
+; Production Value: Off
+; http://php.net/display-errors
+display_errors = Off
+
+; The display of errors which occur during PHP's startup sequence are handled
+; separately from display_errors. PHP's default behavior is to suppress those
+; errors from clients. Turning the display of startup errors on can be useful in
+; debugging configuration problems. But, it's strongly recommended that you
+; leave this setting off on production servers.
+; Default Value: Off
+; Development Value: On
+; Production Value: Off
+; http://php.net/display-startup-errors
+display_startup_errors = Off
+
+; Besides displaying errors, PHP can also log errors to locations such as a
+; server-specific log, STDERR, or a location specified by the error_log
+; directive found below. While errors should not be displayed on productions
+; servers they should still be monitored and logging is a great way to do that.
+; Default Value: Off
+; Development Value: On
+; Production Value: On
+; http://php.net/log-errors
+log_errors = On
+
+; Set maximum length of log_errors. In error_log information about the source is
+; added. The default is 1024 and 0 allows to not apply any maximum length at all.
+; http://php.net/log-errors-max-len
+log_errors_max_len = 1024
+
+; Do not log repeated messages. Repeated errors must occur in same file on same
+; line unless ignore_repeated_source is set true.
+; http://php.net/ignore-repeated-errors
+ignore_repeated_errors = Off
+
+; Ignore source of message when ignoring repeated messages. When this setting
+; is On you will not log errors with repeated messages from different files or
+; source lines.
+; http://php.net/ignore-repeated-source
+ignore_repeated_source = Off
+
+; If this parameter is set to Off, then memory leaks will not be shown (on
+; stdout or in the log). This has only effect in a debug compile, and if
+; error reporting includes E_WARNING in the allowed list
+; http://php.net/report-memleaks
+report_memleaks = On
+
+; This setting is on by default.
+;report_zend_debug = 0
+
+; Store the last error/warning message in $php_errormsg (boolean). Setting this value
+; to On can assist in debugging and is appropriate for development servers. It should
+; however be disabled on production servers.
+; Default Value: Off
+; Development Value: On
+; Production Value: Off
+; http://php.net/track-errors
+track_errors = Off
+
+; Turn off normal error reporting and emit XML-RPC error XML
+; http://php.net/xmlrpc-errors
+;xmlrpc_errors = 0
+
+; An XML-RPC faultCode
+;xmlrpc_error_number = 0
+
+; When PHP displays or logs an error, it has the capability of formatting the
+; error message as HTML for easier reading. This directive controls whether
+; the error message is formatted as HTML or not.
+; Note: This directive is hardcoded to Off for the CLI SAPI
+; Default Value: On
+; Development Value: On
+; Production value: On
+; http://php.net/html-errors
+html_errors = On
+
+; If html_errors is set to On *and* docref_root is not empty, then PHP
+; produces clickable error messages that direct to a page describing the error
+; or function causing the error in detail.
+; You can download a copy of the PHP manual from http://php.net/docs
+; and change docref_root to the base URL of your local copy including the
+; leading '/'. You must also specify the file extension being used including
+; the dot. PHP's default behavior is to leave these settings empty, in which
+; case no links to documentation are generated.
+; Note: Never use this feature for production boxes.
+; http://php.net/docref-root
+; Examples
+;docref_root = "/phpmanual/"
+
+; http://php.net/docref-ext
+;docref_ext = .html
+
+; String to output before an error message. PHP's default behavior is to leave
+; this setting blank.
+; http://php.net/error-prepend-string
+; Example:
+;error_prepend_string = "<span style='color: #ff0000'>"
+
+; String to output after an error message. PHP's default behavior is to leave
+; this setting blank.
+; http://php.net/error-append-string
+; Example:
+;error_append_string = "</span>"
+
+; Log errors to specified file. PHP's default behavior is to leave this value
+; empty.
+; http://php.net/error-log
+; Example:
+;error_log = php_errors.log
+; Log errors to syslog (Event Log on NT, not valid in Windows 95).
+;error_log = syslog
+
+;windows.show_crt_warning
+; Default value: 0
+; Development value: 0
+; Production value: 0
+
+;;;;;;;;;;;;;;;;;
+; Data Handling ;
+;;;;;;;;;;;;;;;;;
+
+; The separator used in PHP generated URLs to separate arguments.
+; PHP's default setting is "&".
+; http://php.net/arg-separator.output
+; Example:
+;arg_separator.output = "&amp;"
+
+; List of separator(s) used by PHP to parse input URLs into variables.
+; PHP's default setting is "&".
+; NOTE: Every character in this directive is considered as separator!
+; http://php.net/arg-separator.input
+; Example:
+;arg_separator.input = ";&"
+
+; This directive determines which super global arrays are registered when PHP
+; starts up. G,P,C,E & S are abbreviations for the following respective super
+; globals: GET, POST, COOKIE, ENV and SERVER. There is a performance penalty
+; paid for the registration of these arrays and because ENV is not as commonly
+; used as the others, ENV is not recommended on productions servers. You
+; can still get access to the environment variables through getenv() should you
+; need to.
+; Default Value: "EGPCS"
+; Development Value: "GPCS"
+; Production Value: "GPCS";
+; http://php.net/variables-order
+variables_order = "GPCS"
+
+; This directive determines which super global data (G,P,C,E & S) should
+; be registered into the super global array REQUEST. If so, it also determines
+; the order in which that data is registered. The values for this directive are
+; specified in the same manner as the variables_order directive, EXCEPT one.
+; Leaving this value empty will cause PHP to use the value set in the
+; variables_order directive. It does not mean it will leave the super globals
+; array REQUEST empty.
+; Default Value: None
+; Development Value: "GP"
+; Production Value: "GP"
+; http://php.net/request-order
+request_order = "GP"
+
+; This directive determines whether PHP registers $argv & $argc each time it
+; runs. $argv contains an array of all the arguments passed to PHP when a script
+; is invoked. $argc contains an integer representing the number of arguments
+; that were passed when the script was invoked. These arrays are extremely
+; useful when running scripts from the command line. When this directive is
+; enabled, registering these variables consumes CPU cycles and memory each time
+; a script is executed. For performance reasons, this feature should be disabled
+; on production servers.
+; Note: This directive is hardcoded to On for the CLI SAPI
+; Default Value: On
+; Development Value: Off
+; Production Value: Off
+; http://php.net/register-argc-argv
+register_argc_argv = Off
+
+; When enabled, the ENV, REQUEST and SERVER variables are created when they're
+; first used (Just In Time) instead of when the script starts. If these
+; variables are not used within a script, having this directive on will result
+; in a performance gain. The PHP directive register_argc_argv must be disabled
+; for this directive to have any affect.
+; http://php.net/auto-globals-jit
+auto_globals_jit = On
+
+; Whether PHP will read the POST data.
+; This option is enabled by default.
+; Most likely, you won't want to disable this option globally. It causes $_POST
+; and $_FILES to always be empty; the only way you will be able to read the
+; POST data will be through the php://input stream wrapper. This can be useful
+; to proxy requests or to process the POST data in a memory efficient fashion.
+; http://php.net/enable-post-data-reading
+;enable_post_data_reading = Off
+
+; Maximum size of POST data that PHP will accept.
+; Its value may be 0 to disable the limit. It is ignored if POST data reading
+; is disabled through enable_post_data_reading.
+; http://php.net/post-max-size
+post_max_size = {{ d7_post_max_size }}
+
+; Automatically add files before PHP document.
+; http://php.net/auto-prepend-file
+auto_prepend_file =
+
+; Automatically add files after PHP document.
+; http://php.net/auto-append-file
+auto_append_file =
+
+; By default, PHP will output a character encoding using
+; the Content-type: header.  To disable sending of the charset, simply
+; set it to be empty.
+;
+; PHP's built-in default is text/html
+; http://php.net/default-mimetype
+default_mimetype = "text/html"
+
+; PHP's default character set is set to empty.
+; http://php.net/default-charset
+;default_charset = "UTF-8"
+
+; Always populate the $HTTP_RAW_POST_DATA variable. PHP's default behavior is
+; to disable this feature. If post reading is disabled through
+; enable_post_data_reading, $HTTP_RAW_POST_DATA is *NOT* populated.
+; http://php.net/always-populate-raw-post-data
+;always_populate_raw_post_data = On
+
+;;;;;;;;;;;;;;;;;;;;;;;;;
+; Paths and Directories ;
+;;;;;;;;;;;;;;;;;;;;;;;;;
+
+; UNIX: "/path1:/path2"
+;include_path = ".:/php/includes"
+;
+; Windows: "\path1;\path2"
+;include_path = ".;c:\php\includes"
+;
+; PHP's default setting for include_path is ".;/path/to/php/pear"
+; http://php.net/include-path
+
+; The root of the PHP pages, used only if nonempty.
+; if PHP was not compiled with FORCE_REDIRECT, you SHOULD set doc_root
+; if you are running php as a CGI under any web server (other than IIS)
+; see documentation for security issues.  The alternate is to use the
+; cgi.force_redirect configuration below
+; http://php.net/doc-root
+doc_root =
+
+; The directory under which PHP opens the script using /~username used only
+; if nonempty.
+; http://php.net/user-dir
+user_dir =
+
+; Directory in which the loadable extensions (modules) reside.
+; http://php.net/extension-dir
+; extension_dir = "./"
+; On windows:
+; extension_dir = "ext"
+
+; Whether or not to enable the dl() function.  The dl() function does NOT work
+; properly in multithreaded servers, such as IIS or Zeus, and is automatically
+; disabled on them.
+; http://php.net/enable-dl
+enable_dl = Off
+
+; cgi.force_redirect is necessary to provide security running PHP as a CGI under
+; most web servers.  Left undefined, PHP turns this on by default.  You can
+; turn it off here AT YOUR OWN RISK
+; **You CAN safely turn this off for IIS, in fact, you MUST.**
+; http://php.net/cgi.force-redirect
+;cgi.force_redirect = 1
+
+; if cgi.nph is enabled it will force cgi to always sent Status: 200 with
+; every request. PHP's default behavior is to disable this feature.
+;cgi.nph = 1
+
+; if cgi.force_redirect is turned on, and you are not running under Apache or Netscape
+; (iPlanet) web servers, you MAY need to set an environment variable name that PHP
+; will look for to know it is OK to continue execution.  Setting this variable MAY
+; cause security issues, KNOW WHAT YOU ARE DOING FIRST.
+; http://php.net/cgi.redirect-status-env
+;cgi.redirect_status_env =
+
+; cgi.fix_pathinfo provides *real* PATH_INFO/PATH_TRANSLATED support for CGI.  PHP's
+; previous behaviour was to set PATH_TRANSLATED to SCRIPT_FILENAME, and to not grok
+; what PATH_INFO is.  For more information on PATH_INFO, see the cgi specs.  Setting
+; this to 1 will cause PHP CGI to fix its paths to conform to the spec.  A setting
+; of zero causes PHP to behave as before.  Default is 1.  You should fix your scripts
+; to use SCRIPT_FILENAME rather than PATH_TRANSLATED.
+; http://php.net/cgi.fix-pathinfo
+;cgi.fix_pathinfo=1
+
+; FastCGI under IIS (on WINNT based OS) supports the ability to impersonate
+; security tokens of the calling client.  This allows IIS to define the
+; security context that the request runs under.  mod_fastcgi under Apache
+; does not currently support this feature (03/17/2002)
+; Set to 1 if running under IIS.  Default is zero.
+; http://php.net/fastcgi.impersonate
+;fastcgi.impersonate = 1
+
+; Disable logging through FastCGI connection. PHP's default behavior is to enable
+; this feature.
+;fastcgi.logging = 0
+
+; cgi.rfc2616_headers configuration option tells PHP what type of headers to
+; use when sending HTTP response code. If it's set 0 PHP sends Status: header that
+; is supported by Apache. When this option is set to 1 PHP will send
+; RFC2616 compliant header.
+; Default is zero.
+; http://php.net/cgi.rfc2616-headers
+;cgi.rfc2616_headers = 0
+
+;;;;;;;;;;;;;;;;
+; File Uploads ;
+;;;;;;;;;;;;;;;;
+
+; Whether to allow HTTP file uploads.
+; http://php.net/file-uploads
+file_uploads = On
+
+; Temporary directory for HTTP uploaded files (will use system default if not
+; specified).
+; http://php.net/upload-tmp-dir
+;upload_tmp_dir =
+
+; Maximum allowed size for uploaded files.
+; http://php.net/upload-max-filesize
+upload_max_filesize = {{ d7_upload_max_filesize }}
+; Maximum number of files that can be uploaded via a single request
+max_file_uploads = 20
+
+;;;;;;;;;;;;;;;;;;
+; Fopen wrappers ;
+;;;;;;;;;;;;;;;;;;
+
+; Whether to allow the treatment of URLs (like http:// or ftp://) as files.
+; http://php.net/allow-url-fopen
+allow_url_fopen = On
+
+; Whether to allow include/require to open URLs (like http:// or ftp://) as files.
+; http://php.net/allow-url-include
+allow_url_include = Off
+
+; Define the anonymous ftp password (your email address). PHP's default setting
+; for this is empty.
+; http://php.net/from
+;from="john@doe.com"
+
+; Define the User-Agent string. PHP's default setting for this is empty.
+; http://php.net/user-agent
+;user_agent="PHP"
+
+; Default timeout for socket based streams (seconds)
+; http://php.net/default-socket-timeout
+default_socket_timeout = 60
+
+; If your scripts have to deal with files from Macintosh systems,
+; or you are running on a Mac and need to deal with files from
+; unix or win32 systems, setting this flag will cause PHP to
+; automatically detect the EOL character in those files so that
+; fgets() and file() will work regardless of the source of the file.
+; http://php.net/auto-detect-line-endings
+;auto_detect_line_endings = Off
+
+;;;;;;;;;;;;;;;;;;;;;;
+; Dynamic Extensions ;
+;;;;;;;;;;;;;;;;;;;;;;
+
+; If you wish to have an extension loaded automatically, use the following
+; syntax:
+;
+;   extension=modulename.extension
+;
+; For example, on Windows:
+;
+;   extension=msql.dll
+;
+; ... or under UNIX:
+;
+;   extension=msql.so
+;
+; ... or with a path:
+;
+;   extension=/path/to/extension/msql.so
+;
+; If you only provide the name of the extension, PHP will look for it in its
+; default extension directory.
+
+;;;;
+; Note: packaged extension modules are now loaded via the .ini files
+; found in the directory /etc/php.d; these are loaded by default.
+;;;;
+
+;;;;;;;;;;;;;;;;;;;
+; Module Settings ;
+;;;;;;;;;;;;;;;;;;;
+
+[CLI Server]
+; Whether the CLI web server uses ANSI color coding in its terminal output.
+cli_server.color = On
+
+[Date]
+; Defines the default timezone used by the date functions
+; http://php.net/date.timezone
+date.timezone = {{ d7_date_timezone }}
+o
+; http://php.net/date.default-latitude
+;date.default_latitude = 31.7667
+
+; http://php.net/date.default-longitude
+;date.default_longitude = 35.2333
+
+; http://php.net/date.sunrise-zenith
+;date.sunrise_zenith = 90.583333
+
+; http://php.net/date.sunset-zenith
+;date.sunset_zenith = 90.583333
+
+[filter]
+; http://php.net/filter.default
+;filter.default = unsafe_raw
+
+; http://php.net/filter.default-flags
+;filter.default_flags =
+
+[iconv]
+;iconv.input_encoding = ISO-8859-1
+;iconv.internal_encoding = ISO-8859-1
+;iconv.output_encoding = ISO-8859-1
+
+[intl]
+;intl.default_locale =
+; This directive allows you to produce PHP errors when some error
+; happens within intl functions. The value is the level of the error produced.
+; Default is 0, which does not produce any errors.
+;intl.error_level = E_WARNING
+
+[sqlite]
+; http://php.net/sqlite.assoc-case
+;sqlite.assoc_case = 0
+
+[sqlite3]
+;sqlite3.extension_dir =
+
+[Pcre]
+;PCRE library backtracking limit.
+; http://php.net/pcre.backtrack-limit
+;pcre.backtrack_limit=100000
+
+;PCRE library recursion limit.
+;Please note that if you set this value to a high number you may consume all
+;the available process stack and eventually crash PHP (due to reaching the
+;stack size limit imposed by the Operating System).
+; http://php.net/pcre.recursion-limit
+;pcre.recursion_limit=100000
+
+[Pdo]
+; Whether to pool ODBC connections. Can be one of "strict", "relaxed" or "off"
+; http://php.net/pdo-odbc.connection-pooling
+;pdo_odbc.connection_pooling=strict
+
+;pdo_odbc.db2_instance_name
+
+[Pdo_mysql]
+; If mysqlnd is used: Number of cache slots for the internal result set cache
+; http://php.net/pdo_mysql.cache_size
+pdo_mysql.cache_size = 2000
+
+; Default socket name for local MySQL connects.  If empty, uses the built-in
+; MySQL defaults.
+; http://php.net/pdo_mysql.default-socket
+pdo_mysql.default_socket=
+
+[Phar]
+; http://php.net/phar.readonly
+;phar.readonly = On
+
+; http://php.net/phar.require-hash
+;phar.require_hash = On
+
+;phar.cache_list =
+
+[mail function]
+; For Win32 only.
+; http://php.net/smtp
+SMTP = localhost
+; http://php.net/smtp-port
+smtp_port = 25
+
+; For Win32 only.
+; http://php.net/sendmail-from
+;sendmail_from = me@example.com
+
+; For Unix only.  You may supply arguments as well (default: "sendmail -t -i").
+; http://php.net/sendmail-path
+sendmail_path = /usr/sbin/sendmail -t -i
+
+; Force the addition of the specified parameters to be passed as extra parameters
+; to the sendmail binary. These parameters will always replace the value of
+; the 5th parameter to mail(), even in safe mode.
+;mail.force_extra_parameters =
+
+; Add X-PHP-Originating-Script: that will include uid of the script followed by the filename
+mail.add_x_header = On
+
+; The path to a log file that will log all mail() calls. Log entries include
+; the full path of the script, line number, To address and headers.
+;mail.log =
+
+[SQL]
+; http://php.net/sql.safe-mode
+sql.safe_mode = Off
+
+[ODBC]
+; http://php.net/odbc.default-db
+;odbc.default_db    =  Not yet implemented
+
+; http://php.net/odbc.default-user
+;odbc.default_user  =  Not yet implemented
+
+; http://php.net/odbc.default-pw
+;odbc.default_pw    =  Not yet implemented
+
+; Controls the ODBC cursor model.
+; Default: SQL_CURSOR_STATIC (default).
+;odbc.default_cursortype
+
+; Allow or prevent persistent links.
+; http://php.net/odbc.allow-persistent
+odbc.allow_persistent = On
+
+; Check that a connection is still valid before reuse.
+; http://php.net/odbc.check-persistent
+odbc.check_persistent = On
+
+; Maximum number of persistent links.  -1 means no limit.
+; http://php.net/odbc.max-persistent
+odbc.max_persistent = -1
+
+; Maximum number of links (persistent + non-persistent).  -1 means no limit.
+; http://php.net/odbc.max-links
+odbc.max_links = -1
+
+; Handling of LONG fields.  Returns number of bytes to variables.  0 means
+; passthru.
+; http://php.net/odbc.defaultlrl
+odbc.defaultlrl = 4096
+
+; Handling of binary data.  0 means passthru, 1 return as is, 2 convert to char.
+; See the documentation on odbc_binmode and odbc_longreadlen for an explanation
+; of odbc.defaultlrl and odbc.defaultbinmode
+; http://php.net/odbc.defaultbinmode
+odbc.defaultbinmode = 1
+
+;birdstep.max_links = -1
+
+[Interbase]
+; Allow or prevent persistent links.
+ibase.allow_persistent = 1
+
+; Maximum number of persistent links.  -1 means no limit.
+ibase.max_persistent = -1
+
+; Maximum number of links (persistent + non-persistent).  -1 means no limit.
+ibase.max_links = -1
+
+; Default database name for ibase_connect().
+;ibase.default_db =
+
+; Default username for ibase_connect().
+;ibase.default_user =
+
+; Default password for ibase_connect().
+;ibase.default_password =
+
+; Default charset for ibase_connect().
+;ibase.default_charset =
+
+; Default timestamp format.
+ibase.timestampformat = "%Y-%m-%d %H:%M:%S"
+
+; Default date format.
+ibase.dateformat = "%Y-%m-%d"
+
+; Default time format.
+ibase.timeformat = "%H:%M:%S"
+
+[MySQL]
+; Allow accessing, from PHP's perspective, local files with LOAD DATA statements
+; http://php.net/mysql.allow_local_infile
+mysql.allow_local_infile = On
+
+; Allow or prevent persistent links.
+; http://php.net/mysql.allow-persistent
+mysql.allow_persistent = On
+
+; If mysqlnd is used: Number of cache slots for the internal result set cache
+; http://php.net/mysql.cache_size
+mysql.cache_size = 2000
+
+; Maximum number of persistent links.  -1 means no limit.
+; http://php.net/mysql.max-persistent
+mysql.max_persistent = -1
+
+; Maximum number of links (persistent + non-persistent).  -1 means no limit.
+; http://php.net/mysql.max-links
+mysql.max_links = -1
+
+; Default port number for mysql_connect().  If unset, mysql_connect() will use
+; the $MYSQL_TCP_PORT or the mysql-tcp entry in /etc/services or the
+; compile-time value defined MYSQL_PORT (in that order).  Win32 will only look
+; at MYSQL_PORT.
+; http://php.net/mysql.default-port
+mysql.default_port =
+
+; Default socket name for local MySQL connects.  If empty, uses the built-in
+; MySQL defaults.
+; http://php.net/mysql.default-socket
+mysql.default_socket =
+
+; Default host for mysql_connect() (doesn't apply in safe mode).
+; http://php.net/mysql.default-host
+mysql.default_host =
+
+; Default user for mysql_connect() (doesn't apply in safe mode).
+; http://php.net/mysql.default-user
+mysql.default_user =
+
+; Default password for mysql_connect() (doesn't apply in safe mode).
+; Note that this is generally a *bad* idea to store passwords in this file.
+; *Any* user with PHP access can run 'echo get_cfg_var("mysql.default_password")
+; and reveal this password!  And of course, any users with read access to this
+; file will be able to reveal the password as well.
+; http://php.net/mysql.default-password
+mysql.default_password =
+
+; Maximum time (in seconds) for connect timeout. -1 means no limit
+; http://php.net/mysql.connect-timeout
+mysql.connect_timeout = 60
+
+; Trace mode. When trace_mode is active (=On), warnings for table/index scans and
+; SQL-Errors will be displayed.
+; http://php.net/mysql.trace-mode
+mysql.trace_mode = Off
+
+[MySQLi]
+
+; Maximum number of persistent links.  -1 means no limit.
+; http://php.net/mysqli.max-persistent
+mysqli.max_persistent = -1
+
+; Allow accessing, from PHP's perspective, local files with LOAD DATA statements
+; http://php.net/mysqli.allow_local_infile
+;mysqli.allow_local_infile = On
+
+; Allow or prevent persistent links.
+; http://php.net/mysqli.allow-persistent
+mysqli.allow_persistent = On
+
+; Maximum number of links.  -1 means no limit.
+; http://php.net/mysqli.max-links
+mysqli.max_links = -1
+
+; If mysqlnd is used: Number of cache slots for the internal result set cache
+; http://php.net/mysqli.cache_size
+mysqli.cache_size = 2000
+
+; Default port number for mysqli_connect().  If unset, mysqli_connect() will use
+; the $MYSQL_TCP_PORT or the mysql-tcp entry in /etc/services or the
+; compile-time value defined MYSQL_PORT (in that order).  Win32 will only look
+; at MYSQL_PORT.
+; http://php.net/mysqli.default-port
+mysqli.default_port = 3306
+
+; Default socket name for local MySQL connects.  If empty, uses the built-in
+; MySQL defaults.
+; http://php.net/mysqli.default-socket
+mysqli.default_socket =
+
+; Default host for mysql_connect() (doesn't apply in safe mode).
+; http://php.net/mysqli.default-host
+mysqli.default_host =
+
+; Default user for mysql_connect() (doesn't apply in safe mode).
+; http://php.net/mysqli.default-user
+mysqli.default_user =
+
+; Default password for mysqli_connect() (doesn't apply in safe mode).
+; Note that this is generally a *bad* idea to store passwords in this file.
+; *Any* user with PHP access can run 'echo get_cfg_var("mysqli.default_pw")
+; and reveal this password!  And of course, any users with read access to this
+; file will be able to reveal the password as well.
+; http://php.net/mysqli.default-pw
+mysqli.default_pw =
+
+; Allow or prevent reconnect
+mysqli.reconnect = Off
+
+[mysqlnd]
+; Enable / Disable collection of general statistics by mysqlnd which can be
+; used to tune and monitor MySQL operations.
+; http://php.net/mysqlnd.collect_statistics
+mysqlnd.collect_statistics = On
+
+; Enable / Disable collection of memory usage statistics by mysqlnd which can be
+; used to tune and monitor MySQL operations.
+; http://php.net/mysqlnd.collect_memory_statistics
+mysqlnd.collect_memory_statistics = Off
+
+; Size of a pre-allocated buffer used when sending commands to MySQL in bytes.
+; http://php.net/mysqlnd.net_cmd_buffer_size
+;mysqlnd.net_cmd_buffer_size = 2048
+
+; Size of a pre-allocated buffer used for reading data sent by the server in
+; bytes.
+; http://php.net/mysqlnd.net_read_buffer_size
+;mysqlnd.net_read_buffer_size = 32768
+
+[OCI8]
+
+; Connection: Enables privileged connections using external
+; credentials (OCI_SYSOPER, OCI_SYSDBA)
+; http://php.net/oci8.privileged-connect
+;oci8.privileged_connect = Off
+
+; Connection: The maximum number of persistent OCI8 connections per
+; process. Using -1 means no limit.
+; http://php.net/oci8.max-persistent
+;oci8.max_persistent = -1
+
+; Connection: The maximum number of seconds a process is allowed to
+; maintain an idle persistent connection. Using -1 means idle
+; persistent connections will be maintained forever.
+; http://php.net/oci8.persistent-timeout
+;oci8.persistent_timeout = -1
+
+; Connection: The number of seconds that must pass before issuing a
+; ping during oci_pconnect() to check the connection validity. When
+; set to 0, each oci_pconnect() will cause a ping. Using -1 disables
+; pings completely.
+; http://php.net/oci8.ping-interval
+;oci8.ping_interval = 60
+
+; Connection: Set this to a user chosen connection class to be used
+; for all pooled server requests with Oracle 11g Database Resident
+; Connection Pooling (DRCP).  To use DRCP, this value should be set to
+; the same string for all web servers running the same application,
+; the database pool must be configured, and the connection string must
+; specify to use a pooled server.
+;oci8.connection_class =
+
+; High Availability: Using On lets PHP receive Fast Application
+; Notification (FAN) events generated when a database node fails. The
+; database must also be configured to post FAN events.
+;oci8.events = Off
+
+; Tuning: This option enables statement caching, and specifies how
+; many statements to cache. Using 0 disables statement caching.
+; http://php.net/oci8.statement-cache-size
+;oci8.statement_cache_size = 20
+
+; Tuning: Enables statement prefetching and sets the default number of
+; rows that will be fetched automatically after statement execution.
+; http://php.net/oci8.default-prefetch
+;oci8.default_prefetch = 100
+
+; Compatibility. Using On means oci_close() will not close
+; oci_connect() and oci_new_connect() connections.
+; http://php.net/oci8.old-oci-close-semantics
+;oci8.old_oci_close_semantics = Off
+
+[PostgreSQL]
+; Allow or prevent persistent links.
+; http://php.net/pgsql.allow-persistent
+pgsql.allow_persistent = On
+
+; Detect broken persistent links always with pg_pconnect().
+; Auto reset feature requires a little overheads.
+; http://php.net/pgsql.auto-reset-persistent
+pgsql.auto_reset_persistent = Off
+
+; Maximum number of persistent links.  -1 means no limit.
+; http://php.net/pgsql.max-persistent
+pgsql.max_persistent = -1
+
+; Maximum number of links (persistent+non persistent).  -1 means no limit.
+; http://php.net/pgsql.max-links
+pgsql.max_links = -1
+
+; Ignore PostgreSQL backends Notice message or not.
+; Notice message logging require a little overheads.
+; http://php.net/pgsql.ignore-notice
+pgsql.ignore_notice = 0
+
+; Log PostgreSQL backends Notice message or not.
+; Unless pgsql.ignore_notice=0, module cannot log notice message.
+; http://php.net/pgsql.log-notice
+pgsql.log_notice = 0
+
+[Sybase-CT]
+; Allow or prevent persistent links.
+; http://php.net/sybct.allow-persistent
+sybct.allow_persistent = On
+
+; Maximum number of persistent links.  -1 means no limit.
+; http://php.net/sybct.max-persistent
+sybct.max_persistent = -1
+
+; Maximum number of links (persistent + non-persistent).  -1 means no limit.
+; http://php.net/sybct.max-links
+sybct.max_links = -1
+
+; Minimum server message severity to display.
+; http://php.net/sybct.min-server-severity
+sybct.min_server_severity = 10
+
+; Minimum client message severity to display.
+; http://php.net/sybct.min-client-severity
+sybct.min_client_severity = 10
+
+; Set per-context timeout
+; http://php.net/sybct.timeout
+;sybct.timeout=
+
+;sybct.packet_size
+
+; The maximum time in seconds to wait for a connection attempt to succeed before returning failure.
+; Default: one minute
+;sybct.login_timeout=
+
+; The name of the host you claim to be connecting from, for display by sp_who.
+; Default: none
+;sybct.hostname=
+
+; Allows you to define how often deadlocks are to be retried. -1 means "forever".
+; Default: 0
+;sybct.deadlock_retry_count=
+
+[bcmath]
+; Number of decimal digits for all bcmath functions.
+; http://php.net/bcmath.scale
+bcmath.scale = 0
+
+[browscap]
+; http://php.net/browscap
+;browscap = extra/browscap.ini
+
+[Session]
+; Handler used to store/retrieve data.
+; http://php.net/session.save-handler
+session.save_handler = files
+
+; Argument passed to save_handler.  In the case of files, this is the path
+; where data files are stored. Note: Windows users have to change this
+; variable in order to use PHP's session functions.
+;
+; The path can be defined as:
+;
+;     session.save_path = "N;/path"
+;
+; where N is an integer.  Instead of storing all the session files in
+; /path, what this will do is use subdirectories N-levels deep, and
+; store the session data in those directories.  This is useful if you
+; or your OS have problems with lots of files in one directory, and is
+; a more efficient layout for servers that handle lots of sessions.
+;
+; NOTE 1: PHP will not create this directory structure automatically.
+;         You can use the script in the ext/session dir for that purpose.
+; NOTE 2: See the section on garbage collection below if you choose to
+;         use subdirectories for session storage
+;
+; The file storage module creates files using mode 600 by default.
+; You can change that by using
+;
+;     session.save_path = "N;MODE;/path"
+;
+; where MODE is the octal representation of the mode. Note that this
+; does not overwrite the process's umask.
+; http://php.net/session.save-path
+
+; RPM note : session directory must be owned by process owner
+; for mod_php, see /etc/httpd/conf.d/php.conf
+; for php-fpm, see /etc/php-fpm.d/*conf
+;session.save_path = "/tmp"
+
+; Whether to use cookies.
+; http://php.net/session.use-cookies
+session.use_cookies = 1
+
+; http://php.net/session.cookie-secure
+;session.cookie_secure =
+
+; This option forces PHP to fetch and use a cookie for storing and maintaining
+; the session id. We encourage this operation as it's very helpful in combating
+; session hijacking when not specifying and managing your own session id. It is
+; not the end all be all of session hijacking defense, but it's a good start.
+; http://php.net/session.use-only-cookies
+session.use_only_cookies = 1
+
+; Name of the session (used as cookie name).
+; http://php.net/session.name
+session.name = PHPSESSID
+
+; Initialize session on request startup.
+; http://php.net/session.auto-start
+session.auto_start = 0
+
+; Lifetime in seconds of cookie or, if 0, until browser is restarted.
+; http://php.net/session.cookie-lifetime
+session.cookie_lifetime = 0
+
+; The path for which the cookie is valid.
+; http://php.net/session.cookie-path
+session.cookie_path = /
+
+; The domain for which the cookie is valid.
+; http://php.net/session.cookie-domain
+session.cookie_domain =
+
+; Whether or not to add the httpOnly flag to the cookie, which makes it inaccessible to browser scripting languages such as JavaScript.
+; http://php.net/session.cookie-httponly
+session.cookie_httponly =
+
+; Handler used to serialize data.  php is the standard serializer of PHP.
+; http://php.net/session.serialize-handler
+session.serialize_handler = php
+
+; Defines the probability that the 'garbage collection' process is started
+; on every session initialization. The probability is calculated by using
+; gc_probability/gc_divisor. Where session.gc_probability is the numerator
+; and gc_divisor is the denominator in the equation. Setting this value to 1
+; when the session.gc_divisor value is 100 will give you approximately a 1% chance
+; the gc will run on any give request.
+; Default Value: 1
+; Development Value: 1
+; Production Value: 1
+; http://php.net/session.gc-probability
+session.gc_probability = 1
+
+; Defines the probability that the 'garbage collection' process is started on every
+; session initialization. The probability is calculated by using the following equation:
+; gc_probability/gc_divisor. Where session.gc_probability is the numerator and
+; session.gc_divisor is the denominator in the equation. Setting this value to 1
+; when the session.gc_divisor value is 100 will give you approximately a 1% chance
+; the gc will run on any give request. Increasing this value to 1000 will give you
+; a 0.1% chance the gc will run on any give request. For high volume production servers,
+; this is a more efficient approach.
+; Default Value: 100
+; Development Value: 1000
+; Production Value: 1000
+; http://php.net/session.gc-divisor
+session.gc_divisor = 1000
+
+; After this number of seconds, stored data will be seen as 'garbage' and
+; cleaned up by the garbage collection process.
+; http://php.net/session.gc-maxlifetime
+session.gc_maxlifetime = 1440
+
+; NOTE: If you are using the subdirectory option for storing session files
+;       (see session.save_path above), then garbage collection does *not*
+;       happen automatically.  You will need to do your own garbage
+;       collection through a shell script, cron entry, or some other method.
+;       For example, the following script would is the equivalent of
+;       setting session.gc_maxlifetime to 1440 (1440 seconds = 24 minutes):
+;          find /path/to/sessions -cmin +24 | xargs rm
+
+; PHP 4.2 and less have an undocumented feature/bug that allows you to
+; to initialize a session variable in the global scope.
+; PHP 4.3 and later will warn you, if this feature is used.
+; You can disable the feature and the warning separately. At this time,
+; the warning is only displayed, if bug_compat_42 is enabled. This feature
+; introduces some serious security problems if not handled correctly. It's
+; recommended that you do not use this feature on production servers. But you
+; should enable this on development servers and enable the warning as well. If you
+; do not enable the feature on development servers, you won't be warned when it's
+; used and debugging errors caused by this can be difficult to track down.
+; Default Value: On
+; Development Value: On
+; Production Value: Off
+; http://php.net/session.bug-compat-42
+session.bug_compat_42 = Off
+
+; This setting controls whether or not you are warned by PHP when initializing a
+; session value into the global space. session.bug_compat_42 must be enabled before
+; these warnings can be issued by PHP. See the directive above for more information.
+; Default Value: On
+; Development Value: On
+; Production Value: Off
+; http://php.net/session.bug-compat-warn
+session.bug_compat_warn = Off
+
+; Check HTTP Referer to invalidate externally stored URLs containing ids.
+; HTTP_REFERER has to contain this substring for the session to be
+; considered as valid.
+; http://php.net/session.referer-check
+session.referer_check =
+
+; How many bytes to read from the file.
+; http://php.net/session.entropy-length
+;session.entropy_length = 32
+
+; Specified here to create the session id.
+; http://php.net/session.entropy-file
+; Defaults to /dev/urandom
+; On systems that don't have /dev/urandom but do have /dev/arandom, this will default to /dev/arandom
+; If neither are found at compile time, the default is no entropy file.
+; On windows, setting the entropy_length setting will activate the
+; Windows random source (using the CryptoAPI)
+;session.entropy_file = /dev/urandom
+
+; Set to {nocache,private,public,} to determine HTTP caching aspects
+; or leave this empty to avoid sending anti-caching headers.
+; http://php.net/session.cache-limiter
+session.cache_limiter = nocache
+
+; Document expires after n minutes.
+; http://php.net/session.cache-expire
+session.cache_expire = 180
+
+; trans sid support is disabled by default.
+; Use of trans sid may risk your users security.
+; Use this option with caution.
+; - User may send URL contains active session ID
+;   to other person via. email/irc/etc.
+; - URL that contains active session ID may be stored
+;   in publicly accessible computer.
+; - User may access your site with the same session ID
+;   always using URL stored in browser's history or bookmarks.
+; http://php.net/session.use-trans-sid
+session.use_trans_sid = 0
+
+; Select a hash function for use in generating session ids.
+; Possible Values
+;   0  (MD5 128 bits)
+;   1  (SHA-1 160 bits)
+; This option may also be set to the name of any hash function supported by
+; the hash extension. A list of available hashes is returned by the hash_algos()
+; function.
+; http://php.net/session.hash-function
+session.hash_function = 0
+
+; Define how many bits are stored in each character when converting
+; the binary hash data to something readable.
+; Possible values:
+;   4  (4 bits: 0-9, a-f)
+;   5  (5 bits: 0-9, a-v)
+;   6  (6 bits: 0-9, a-z, A-Z, "-", ",")
+; Default Value: 4
+; Development Value: 5
+; Production Value: 5
+; http://php.net/session.hash-bits-per-character
+session.hash_bits_per_character = 5
+
+; The URL rewriter will look for URLs in a defined set of HTML tags.
+; form/fieldset are special; if you include them here, the rewriter will
+; add a hidden <input> field with the info which is otherwise appended
+; to URLs.  If you want XHTML conformity, remove the form entry.
+; Note that all valid entries require a "=", even if no value follows.
+; Default Value: "a=href,area=href,frame=src,form=,fieldset="
+; Development Value: "a=href,area=href,frame=src,input=src,form=fakeentry"
+; Production Value: "a=href,area=href,frame=src,input=src,form=fakeentry"
+; http://php.net/url-rewriter.tags
+url_rewriter.tags = "a=href,area=href,frame=src,input=src,form=fakeentry"
+
+; Enable upload progress tracking in $_SESSION
+; Default Value: On
+; Development Value: On
+; Production Value: On
+; http://php.net/session.upload-progress.enabled
+;session.upload_progress.enabled = On
+
+; Cleanup the progress information as soon as all POST data has been read
+; (i.e. upload completed).
+; Default Value: On
+; Development Value: On
+; Production Value: On
+; http://php.net/session.upload-progress.cleanup
+;session.upload_progress.cleanup = On
+
+; A prefix used for the upload progress key in $_SESSION
+; Default Value: "upload_progress_"
+; Development Value: "upload_progress_"
+; Production Value: "upload_progress_"
+; http://php.net/session.upload-progress.prefix
+;session.upload_progress.prefix = "upload_progress_"
+
+; The index name (concatenated with the prefix) in $_SESSION
+; containing the upload progress information
+; Default Value: "PHP_SESSION_UPLOAD_PROGRESS"
+; Development Value: "PHP_SESSION_UPLOAD_PROGRESS"
+; Production Value: "PHP_SESSION_UPLOAD_PROGRESS"
+; http://php.net/session.upload-progress.name
+;session.upload_progress.name = "PHP_SESSION_UPLOAD_PROGRESS"
+
+; How frequently the upload progress should be updated.
+; Given either in percentages (per-file), or in bytes
+; Default Value: "1%"
+; Development Value: "1%"
+; Production Value: "1%"
+; http://php.net/session.upload-progress.freq
+;session.upload_progress.freq =  "1%"
+
+; The minimum delay between updates, in seconds
+; Default Value: 1
+; Development Value: 1
+; Production Value: 1
+; http://php.net/session.upload-progress.min-freq
+;session.upload_progress.min_freq = "1"
+
+[MSSQL]
+; Allow or prevent persistent links.
+mssql.allow_persistent = On
+
+; Maximum number of persistent links.  -1 means no limit.
+mssql.max_persistent = -1
+
+; Maximum number of links (persistent+non persistent).  -1 means no limit.
+mssql.max_links = -1
+
+; Minimum error severity to display.
+mssql.min_error_severity = 10
+
+; Minimum message severity to display.
+mssql.min_message_severity = 10
+
+; Compatibility mode with old versions of PHP 3.0.
+mssql.compatability_mode = Off
+
+; Connect timeout
+;mssql.connect_timeout = 5
+
+; Query timeout
+;mssql.timeout = 60
+
+; Valid range 0 - 2147483647.  Default = 4096.
+;mssql.textlimit = 4096
+
+; Valid range 0 - 2147483647.  Default = 4096.
+;mssql.textsize = 4096
+
+; Limits the number of records in each batch.  0 = all records in one batch.
+;mssql.batchsize = 0
+
+; Specify how datetime and datetim4 columns are returned
+; On => Returns data converted to SQL server settings
+; Off => Returns values as YYYY-MM-DD hh:mm:ss
+;mssql.datetimeconvert = On
+
+; Use NT authentication when connecting to the server
+mssql.secure_connection = Off
+
+; Specify max number of processes. -1 = library default
+; msdlib defaults to 25
+; FreeTDS defaults to 4096
+;mssql.max_procs = -1
+
+; Specify client character set.
+; If empty or not set the client charset from freetds.conf is used
+; This is only used when compiled with FreeTDS
+;mssql.charset = "ISO-8859-1"
+
+[Assertion]
+; Assert(expr); active by default.
+; http://php.net/assert.active
+;assert.active = On
+
+; Issue a PHP warning for each failed assertion.
+; http://php.net/assert.warning
+;assert.warning = On
+
+; Don't bail out by default.
+; http://php.net/assert.bail
+;assert.bail = Off
+
+; User-function to be called if an assertion fails.
+; http://php.net/assert.callback
+;assert.callback = 0
+
+; Eval the expression with current error_reporting().  Set to true if you want
+; error_reporting(0) around the eval().
+; http://php.net/assert.quiet-eval
+;assert.quiet_eval = 0
+
+[mbstring]
+; language for internal character representation.
+; http://php.net/mbstring.language
+;mbstring.language = Japanese
+
+; internal/script encoding.
+; Some encoding cannot work as internal encoding.
+; (e.g. SJIS, BIG5, ISO-2022-*)
+; http://php.net/mbstring.internal-encoding
+;mbstring.internal_encoding = EUC-JP
+
+; http input encoding.
+; http://php.net/mbstring.http-input
+;mbstring.http_input = auto
+
+; http output encoding. mb_output_handler must be
+; registered as output buffer to function
+; http://php.net/mbstring.http-output
+;mbstring.http_output = SJIS
+
+; enable automatic encoding translation according to
+; mbstring.internal_encoding setting. Input chars are
+; converted to internal encoding by setting this to On.
+; Note: Do _not_ use automatic encoding translation for
+;       portable libs/applications.
+; http://php.net/mbstring.encoding-translation
+;mbstring.encoding_translation = Off
+
+; automatic encoding detection order.
+; auto means
+; http://php.net/mbstring.detect-order
+;mbstring.detect_order = auto
+
+; substitute_character used when character cannot be converted
+; one from another
+; http://php.net/mbstring.substitute-character
+;mbstring.substitute_character = none;
+
+; overload(replace) single byte functions by mbstring functions.
+; mail(), ereg(), etc are overloaded by mb_send_mail(), mb_ereg(),
+; etc. Possible values are 0,1,2,4 or combination of them.
+; For example, 7 for overload everything.
+; 0: No overload
+; 1: Overload mail() function
+; 2: Overload str*() functions
+; 4: Overload ereg*() functions
+; http://php.net/mbstring.func-overload
+;mbstring.func_overload = 0
+
+; enable strict encoding detection.
+;mbstring.strict_detection = Off
+
+; This directive specifies the regex pattern of content types for which mb_output_handler()
+; is activated.
+; Default: mbstring.http_output_conv_mimetype=^(text/|application/xhtml\+xml)
+;mbstring.http_output_conv_mimetype=
+
+[gd]
+; Tell the jpeg decode to ignore warnings and try to create
+; a gd image. The warning will then be displayed as notices
+; disabled by default
+; http://php.net/gd.jpeg-ignore-warning
+;gd.jpeg_ignore_warning = 0
+
+[exif]
+; Exif UNICODE user comments are handled as UCS-2BE/UCS-2LE and JIS as JIS.
+; With mbstring support this will automatically be converted into the encoding
+; given by corresponding encode setting. When empty mbstring.internal_encoding
+; is used. For the decode settings you can distinguish between motorola and
+; intel byte order. A decode setting cannot be empty.
+; http://php.net/exif.encode-unicode
+;exif.encode_unicode = ISO-8859-15
+
+; http://php.net/exif.decode-unicode-motorola
+;exif.decode_unicode_motorola = UCS-2BE
+
+; http://php.net/exif.decode-unicode-intel
+;exif.decode_unicode_intel    = UCS-2LE
+
+; http://php.net/exif.encode-jis
+;exif.encode_jis =
+
+; http://php.net/exif.decode-jis-motorola
+;exif.decode_jis_motorola = JIS
+
+; http://php.net/exif.decode-jis-intel
+;exif.decode_jis_intel    = JIS
+
+[Tidy]
+; The path to a default tidy configuration file to use when using tidy
+; http://php.net/tidy.default-config
+;tidy.default_config = /usr/local/lib/php/default.tcfg
+
+; Should tidy clean and repair output automatically?
+; WARNING: Do not use this option if you are generating non-html content
+; such as dynamic images
+; http://php.net/tidy.clean-output
+tidy.clean_output = Off
+
+[soap]
+; Enables or disables WSDL caching feature.
+; http://php.net/soap.wsdl-cache-enabled
+soap.wsdl_cache_enabled=1
+
+; Sets the directory name where SOAP extension will put cache files.
+; http://php.net/soap.wsdl-cache-dir
+soap.wsdl_cache_dir="/tmp"
+
+; (time to live) Sets the number of second while cached file will be used
+; instead of original one.
+; http://php.net/soap.wsdl-cache-ttl
+soap.wsdl_cache_ttl=86400
+
+; Sets the size of the cache limit. (Max. number of WSDL files to cache)
+soap.wsdl_cache_limit = 5
+
+[sysvshm]
+; A default size of the shared memory segment
+;sysvshm.init_mem = 10000
+
+[ldap]
+; Sets the maximum number of open links or -1 for unlimited.
+ldap.max_links = -1
+
+[mcrypt]
+; For more information about mcrypt settings see http://php.net/mcrypt-module-open
+
+; Directory where to load mcrypt algorithms
+; Default: Compiled in into libmcrypt (usually /usr/local/lib/libmcrypt)
+;mcrypt.algorithms_dir=
+
+; Directory where to load mcrypt modes
+; Default: Compiled in into libmcrypt (usually /usr/local/lib/libmcrypt)
+;mcrypt.modes_dir=
+
+[dba]
+;dba.default_handler=
+
+; Local Variables:
+; tab-width: 4
+; End:

--- a/templates/php.ini.j2
+++ b/templates/php.ini.j2
@@ -1379,7 +1379,7 @@ session.auto_start = 0
 
 ; Lifetime in seconds of cookie or, if 0, until browser is restarted.
 ; http://php.net/session.cookie-lifetime
-session.cookie_lifetime = 0
+session.cookie_lifetime = {{ d7_session_cookie_lifetime }}
 
 ; The path for which the cookie is valid.
 ; http://php.net/session.cookie-path
@@ -1407,7 +1407,7 @@ session.serialize_handler = php
 ; Development Value: 1
 ; Production Value: 1
 ; http://php.net/session.gc-probability
-session.gc_probability = 1
+session.gc_probability = {{ d7_session_gc_probability }} 
 
 ; Defines the probability that the 'garbage collection' process is started on every
 ; session initialization. The probability is calculated by using the following equation:
@@ -1421,7 +1421,7 @@ session.gc_probability = 1
 ; Development Value: 1000
 ; Production Value: 1000
 ; http://php.net/session.gc-divisor
-session.gc_divisor = 1000
+session.gc_divisor = {{ d7_session_gc_divisior }}
 
 ; After this number of seconds, stored data will be seen as 'garbage' and
 ; cleaned up by the garbage collection process.


### PR DESCRIPTION
# includes #103 and #102 and #104, but adds the following:

Adds `drupal-files.include` with settings harvested from .htaccess for `sites/default/files` and `sites/default/files/private`.
 
Motivation and Context
----------------------
We're doing away with dynamic .htaccess and this captures settings in place to protect file dirs. 

Testing
-------------------------
- [x] denies access to private files 