### PR TITLE
Completely move private files config to their own include

### DIFF
--- a/files/d7_httpd_conf.sh
+++ b/files/d7_httpd_conf.sh
@@ -70,6 +70,9 @@ if [ "$SITETYPE" == "master" ]; then
     AllowOverride None
     Include /etc/httpd/conf.d/drupal.include
   </Directory>
+
+  Include /etc/httpd/conf.d/drupal-files.include
+
 EOF
 
   for SUBSITEPATH in $( cat "${SITEPATH}/etc/subsites" ); do

--- a/files/drupal.include
+++ b/files/drupal.include
@@ -147,28 +147,3 @@ DirectoryIndex index.php index.html index.htm
   # Disable content sniffing, since it's an attack vector.
   Header always set X-Content-Type-Options nosniff
 </IfModule>
-
-
-# oulib settings for Drupal files
-<Directory "/srv/*/drupal/sites/default/files">
-  Options None
-  Options +FollowSymLinks
-
-  # Set the catch-all handler to prevent scripts from being executed.
-  SetHandler Drupal_Security_Do_Not_Remove_See_SA_2006_006
-
-  # Override the handler again if we're run later in the evaluation list.
-  <Files *>
-    SetHandler Drupal_Security_Do_Not_Remove_See_SA_2013_003
-  </Files>
-
-  # If we know how to do it safely, disable the PHP engine entirely.
-  <IfModule mod_php5.c>
-    php_flag engine off
-  </IfModule>
-</Directory>
-
-# oulib settings for Drupal files
-<Directory "/srv/*/drupal/sites/default/files/private">
-  Deny from all
-</Directory>


### PR DESCRIPTION
Motivation and Context
----------------------

Private files config needs to be in its own include because it can't be part of the `<directory>` section where the rest of the Drupal `.htaccess` stuff gets inserted. 

How Has This Been Tested?
-------------------------
Successful provision of sites with correct 403 behavior for hidden files sans `.htaccess`.
