### PR TITLE
Add CAS server settings config.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -50,3 +50,6 @@ d7_date_timezone: "America/Chicago"
 d7_session_cookie_lifetime: "2000000"
 d7_session_gc_probability: "1"
 d7_session_gc_divisor: "100"
+
+# D7 CAS Host
+d7_cas: ""

--- a/files/d7_init.sh
+++ b/files/d7_init.sh
@@ -65,6 +65,9 @@ read -r -e -p "Enter base URL without trailing slash: " -i "${BASE_URL}" MY_BASE
 # Get cookie domain. Default is site name, but may need to be changed for SSO.
 read -r -e -p "Enter cookie domain: " -i "${COOKIE_DOMAIN}" MY_COOKIE_DOMAIN
 
+# Get CAS host.
+read -r -e -p "Enter CAS server: " -i "${D7_CAS}" MY_CAS
+
 # Get mysql host
 read -r -e -p "Enter MYSQL host name: " -i "$D7_DBHOST" MY_DBHOST
 
@@ -131,6 +134,9 @@ read -r -d '' SETTINGSPHP <<- EOF
 
 ## Include reverse proxy config (empty if no proxy)
 include '/opt/d7/etc/d7_proxy.inc.php';
+
+## Set CAS config
+\$conf['cas_server'] = '${MY_CAS}';
 
 EOF
 

--- a/tasks/yum.yml
+++ b/tasks/yum.yml
@@ -13,6 +13,7 @@
     - php-gd
     - php-soap
     - php-mbstring
+    - php-pear-CAS
     - mariadb
     - gcc
 

--- a/templates/d7_conf.sh.j2
+++ b/templates/d7_conf.sh.j2
@@ -12,3 +12,6 @@ D7_DBHOST="{{ mariadb_host }}"
 D7_DBPORT="{{ mariadb_port }}"
 D7_DBSU="{{ mariadb_root_user}}"
 
+# Default CAS host
+D7_CAS="{{ d7_cas }}"
+


### PR DESCRIPTION
* Set system default cas server
* Add cas server settings to interview
* Include cas server config in settings.php
* Yum Install php-pear-cas 

Motivation and Context
----------------------
We want a system-wide CAS config that we can override on a site-wise basis. 

How Has This Been Tested?
-------------------------
Successful provision of minimal D7 CAS auth without manual fiddling. 
