### PR TITLE
Clean subsite config in master site when subsite is removed. 

### DIFF
--- a/files/d7_httpd_conf.sh
+++ b/files/d7_httpd_conf.sh
@@ -49,7 +49,7 @@ echo "Generating Apache config for ${SITEPATH}."
 sudo -u apache mkdir -p "$SITEPATH/etc"
 
 if [ "$SITETYPE" == "master" ]; then
-  echo "Generating ${SITEPATH}/etc/srv_${SITE}.conf with additional subsite information."
+  echo "Generating master site config ${SITEPATH}/etc/srv_${SITE}.conf ."
 
   # Start off normally
   read -r -d '' SRV_SITE_CONF <<- EOF
@@ -75,8 +75,20 @@ if [ "$SITETYPE" == "master" ]; then
 
 EOF
 
-  for SUBSITEPATH in $( cat "${SITEPATH}/etc/subsites" ); do
-      SUBSITE=$(basename "$SUBSITEPATH")
+
+  [ -e "${SITEPATH}/etc/subsites" ] && SUBSITEPATHS=$( find "${SITEPATH}/etc/subsites" -print )
+
+  for SUBSITEPATH in $SUBSITEPATHS ; do
+
+      SUBSITE=$(basename "${SUBSITEPATH}")
+      echo "Adding subsite ${SUBSITE}"
+
+      if [ ! -e "${SUBSITEPATH}" ]; then
+	  echo "... no site found at ${SUBSITEPATH}, removing."
+	  unlink "${SITEPATH}/etc/subsites/${SUBSITE}"
+	  continue;
+      fi
+
       read -r -d '' SRV_SITE_CONF <<- EOF
 
 ${SRV_SITE_CONF}

--- a/files/d7_httpd_conf.sh
+++ b/files/d7_httpd_conf.sh
@@ -76,16 +76,15 @@ if [ "$SITETYPE" == "master" ]; then
 EOF
 
 
-  [ -e "${SITEPATH}/etc/subsites" ] && SUBSITEPATHS=$( find "${SITEPATH}/etc/subsites" -print )
+  [ -e "${SITEPATH}/etc/subsites" ] && SUBSITES=$( ls "${SITEPATH}/etc/subsites" )
 
-  for SUBSITEPATH in $SUBSITEPATHS ; do
+  for SUBSITE in $SUBSITES ; do
 
-      SUBSITE=$(basename "${SUBSITEPATH}")
       echo "Adding subsite ${SUBSITE}"
 
-      if [ ! -e "${SUBSITEPATH}" ]; then
-	  echo "... no site found at ${SUBSITEPATH}, removing."
-	  unlink "${SITEPATH}/etc/subsites/${SUBSITE}"
+      if [ ! -d "/srv/${SUBSITE}" ]; then
+	  echo "... no site found at /srv/${SUBSITE}, removing from config."
+	  rm "${SITEPATH}/etc/subsites/${SUBSITE}"
 	  continue;
       fi
 

--- a/files/d7_init.sh
+++ b/files/d7_init.sh
@@ -95,7 +95,8 @@ sudo -u apache chmod 775 "$SITEPATH"
 # Let master site know about subsite
 if [ "$SITETYPE" == "sub" ]; then
     echo "Register with master at ${MASTERPATH}."
-    echo "${SITEPATH}" >> "${MASTERPATH}/etc/subsites"
+    mkdir -v -p "${MASTERPATH}/etc/subsites"
+    ln -v -s "${SITEPATH}" "${MASTERPATH}/etc/subsites/${SITE}"
 fi
 
 ## Install drupal core

--- a/files/d7_init.sh
+++ b/files/d7_init.sh
@@ -96,7 +96,7 @@ sudo -u apache chmod 775 "$SITEPATH"
 if [ "$SITETYPE" == "sub" ]; then
     echo "Register with master at ${MASTERPATH}."
     mkdir -v -p "${MASTERPATH}/etc/subsites"
-    ln -v -s "${SITEPATH}" "${MASTERPATH}/etc/subsites/${SITE}"
+    touch "${MASTERPATH}/etc/subsites/${SITE}"
 fi
 
 ## Install drupal core


### PR DESCRIPTION
* Use folder of symlinks  as data structure for tracking subsites.
* Allow for cleanup outdated config for sites that have been removed

Subsite config is removed by  `d7_httpd_conf.sh`, which was chosen over direct removal in to maintain the currently minimal coupling between subsite and master. This also fits better with the pattern that a script modifies the path specified as its first argument. 


Motivation and Context
----------------------
Closes #109 by providing a process for removing subsite config from master after subsite is cleaned. 

Testing
-------------------------
In progress. 
