### PR TITLE
Delete extraneous character 'o' near timezone setting

### DIFF
--- a/templates/php.ini.j2
+++ b/templates/php.ini.j2
@@ -875,7 +875,7 @@ cli_server.color = On
 ; Defines the default timezone used by the date functions
 ; http://php.net/date.timezone
 date.timezone = {{ d7_date_timezone }}
-o
+
 ; http://php.net/date.default-latitude
 ;date.default_latitude = 31.7667
 


### PR DESCRIPTION
Delete stand-alone typo, probably a remnant of the word "Chicago"

Motivation and Context
----------------------
Typos are bad, and we're seeing a weird timezone-related bug that might be related. 

Testing
-------------------------
Wishes and Promises. Vagrant testing up next. 
