### PR TITLE
Use Console Table version that works with PHP7

### DIFF
--- a/tasks/drush.yml
+++ b/tasks/drush.yml
@@ -4,7 +4,9 @@
   become_user: composer
   shell: |
     .  /etc/profile.d/enablephp.sh
-    /opt/php/bin/composer.phar init --require=drush/drush:7.* -n
+    /opt/php/bin/composer.phar init -n
+    /opt/php/bin/composer.phar require "pear/console_table:1.3.1 as 1.2.1"
+    /opt/php/bin/composer.phar require "drush/drush:7.*"
     /opt/php/bin/composer.phar config bin-dir /opt/php/bin
     /opt/php/bin/composer.phar install
   args:


### PR DESCRIPTION
1.3.1 is compatible with 1.2.1 and has fixes for PHP 7 errors, so we force override.

