### PR TITLE
Update dependencies (needed to account for console_table alias)

### DIFF
--- a/tasks/drush.yml
+++ b/tasks/drush.yml
@@ -4,9 +4,9 @@
   become_user: composer
   shell: |
     .  /etc/profile.d/enablephp.sh
-    /opt/php/bin/composer.phar init -n
+    /opt/php/bin/composer.phar init --no-interaction
     /opt/php/bin/composer.phar require "pear/console_table:1.3.1 as 1.2.1"
-    /opt/php/bin/composer.phar require "drush/drush:7.*"
+    /opt/php/bin/composer.phar require  --update-with-all-dependencies "drush/drush:7.*"
     /opt/php/bin/composer.phar config bin-dir /opt/php/bin
     /opt/php/bin/composer.phar install
   args:


### PR DESCRIPTION
Update all dependencies on composer install to make console_table version alias work properly. 

